### PR TITLE
Club flow: firebase

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/data/Club.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Club.java
@@ -1,29 +1,23 @@
 package com.google.sps.data;
 
-import java.util.Collection;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.List;
 
- 
-/**
- * Class representing a Club.
- *
- * Note: The private variables in this class are converted into JSON.
- */
+
 public class Club {
   
-  private final long id;
+  private final String id;
   private String name;
   private String description;
   private String announcement;
-  private Collection<String> posts;
-  private long ownerID;
-  private Collection<Long> memberIDs;
-  private Collection<Long> inviteIDs;
+  private List<String> posts;
+  private String ownerID;
+  private List<String> memberIDs;
+  private List<String> inviteIDs;
   private String gbookID;
 
-  public Club(long id, String name, String description, String announcement, Collection<String> posts, 
-      long ownerID, Collection<Long> memberIDs, Collection<Long> inviteIDs, String gbookID) {
+  public Club(String id, String name, String description, String announcement, List<String> posts, 
+      String ownerID, List<String> memberIDs, List<String> inviteIDs, String gbookID) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -35,15 +29,23 @@ public class Club {
         this.gbookID = gbookID;
   }
 
-  public Club(long id, String name, String description, String announcement, long ownerID, String gbookID){
-    this(id, name, description, announcement, new ArrayList<String>(), ownerID, new HashSet<Long>(), new HashSet<Long>(), gbookID);
+  public Club(String id, String name, String description, String ownerID, String gbookID){
+    this(id, name, description, "", new ArrayList<String>(), ownerID, new ArrayList<String>(), new ArrayList<String>(), gbookID);
   }
 
-  public Club(long id, String name, String description, long ownerID, String gbookID) {
-    this(id, name, description, "", ownerID, gbookID);
+  public Club(String id, String name, String ownerID, String gbookID) {
+    this(id, name, "", ownerID, gbookID);
+  }
+
+  public Club(String id, String name, String ownerID) {
+    this(id, name, "", ownerID, "");
+  }
+
+  public Club() {
+    this("", "", "");
   }
  
-  public long getID() {
+  public String getID() {
     return this.id;
   }
  
@@ -71,7 +73,7 @@ public class Club {
     this.announcement = announcement;
   }
 
-  public Collection<String> getPosts() {
+  public List<String> getPosts() {
     return this.posts;
   }
 
@@ -83,53 +85,53 @@ public class Club {
     this.posts.clear();
   }
 
-  public long getOwnerID() {
+  public String getOwnerID() {
     return ownerID;
   }
 
-  public void setOwnerID(long ownerID) {
+  public void setOwnerID(String ownerID) {
     this.ownerID = ownerID;
   }
  
-  public Collection<Long> getMemberIDs() {
+  public List<String> getMemberIDs() {
     return this.memberIDs;
   }
 
-  public void removeMember(long memberID) {
+  public void removeMember(String memberID) {
     memberIDs.remove(memberID);
   }
 
-  public void removeMembers(Collection<Long> memberIDs) {
-    for (Long l : memberIDs) {
-      this.memberIDs.remove(l);
+  public void removeMembers(List<String> memberIDs) {
+    for (String m : memberIDs) {
+      this.memberIDs.remove(m);
     }
   }
  
-  public Collection<Long> getInviteIDs() {
+  public List<String> getInviteIDs() {
     return this.inviteIDs;
   }
 
-  public void invite(long inviteID) {
+  public void invite(String inviteID) {
     inviteIDs.add(inviteID);
   }
 
-  public void invite(Collection<Long> inviteIDs) {
-    for (Long l : inviteIDs) {
-      this.inviteIDs.add(l);
+  public void invite(List<String> inviteIDs) {
+    for (String i : inviteIDs) {
+      this.inviteIDs.add(i);
     }
   }
 
-  public void uninvite(Long uninviteID) {
+  public void uninvite(String uninviteID) {
     inviteIDs.remove(uninviteID);
   }
 
-  public void uninvite(Collection<Long> uninviteIDs) {
-    for (Long l : uninviteIDs) {
-      this.inviteIDs.remove(l);
+  public void uninvite(List<String> uninviteIDs) {
+    for (String u : uninviteIDs) {
+      this.inviteIDs.remove(u);
     }
   }
 
-  public boolean addMember(long memberID) {
+  public boolean addMember(String memberID) {
     if (inviteIDs.contains(memberID)) {
       inviteIDs.remove(memberID);
       memberIDs.add(memberID);

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -142,7 +142,7 @@ public class ClubServlet extends HttpServlet {
 
     if (jsonObject.get("name") != null) {
       String name = jsonObject.get("name").getAsString();
-      club.setName(name)
+      club.setName(name);
       update.put("name", name);
     }
     if (jsonObject.get("description") != null) {
@@ -164,7 +164,7 @@ public class ClubServlet extends HttpServlet {
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       return;
     }
-    
+
     response.setContentType("application/json;");
     response.getWriter().println(gson.toJson(club));
   }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -1,166 +1,134 @@
 package com.google.sps.servlets;
 
-import com.google.sps.data.Club;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.SetOptions;
+import com.google.cloud.firestore.WriteResult;
 
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.FetchOptions;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import java.io.IOException;
+import com.google.sps.data.Club;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that allows users to post and get clubs. */
+
 @WebServlet("/api/clubs")
 public class ClubServlet extends HttpServlet {
+  private Firestore db; 
+  private CollectionReference clubs;
+  private Gson gson;
 
-  private JsonObject createRequestBodyJson(HttpServletRequest request) {
-    JsonObject jsonObject = new JsonObject();
-    StringBuffer jb = new StringBuffer();
-    String line = null;
-    try {
-      BufferedReader reader = new BufferedReader(new InputStreamReader((request.getInputStream())));
-      while ((line = reader.readLine()) != null) {
-       jb.append(line);
-      }
-    } catch (Exception e) { 
-      System.err.println("Error: " + e);
-    }
-    try {
-      Gson gson = new Gson();
-      JsonElement data = JsonParser.parseString(jb.toString());
-      jsonObject = data.getAsJsonObject();
-    } catch (Exception e) {
-      System.err.println("Error parsing JSON request string");
-    }
-
-    return jsonObject;
+  public ClubServlet() throws IOException {
+    db = Utility.getFirestoreDb();
+    clubs = db.collection("clubs");
+    gson = new Gson();
   }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Club");
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastore.prepare(query);
-    List<Entity> entities = results.asList(FetchOptions.Builder.withLimit(5));
-
-    List<Club> clubs = new ArrayList<>();
-    for(Entity e : entities) {
-      long id = (long) e.getKey().getId();
-      String name = (String) e.getProperty("name");
-      String description = (String) e.getProperty("description");
-      String announcement = (String) e.getProperty("announcement");
-
-      @SuppressWarnings("unchecked") // Cast can't verify generic type.
-      Collection<String> posts = (ArrayList<String>) e.getProperty("posts");
-
-      @SuppressWarnings("unchecked") // Cast can't verify generic type.
-      Collection<Long> memberIDs = (HashSet<Long>) e.getProperty("memberIDs");
-      
-      @SuppressWarnings("unchecked") // Cast can't verify generic type.
-      Collection<Long> inviteIDs = (HashSet<Long>) e.getProperty("inviteIDs");
-
-      long ownerID = (long) e.getProperty("ownerID");
-      String gbookID = (String) e.getProperty("gbookID");
-      Club club = new Club(id, name, description, announcement, ownerID, gbookID);
-      clubs.add(club);
+    List<Club> result = new ArrayList<>();
+    if (request.getParameter("id") != null) {
+      DocumentReference docRef = clubs.document(request.getParameter("id"));
+      ApiFuture<DocumentSnapshot> future = docRef.get();
+      DocumentSnapshot document = null;
+      Club club = null;
+      try {
+        document = future.get();
+        if (document.exists()) {
+          club = document.toObject(Club.class);
+        } else {
+          System.err.println("Error: no such document!");
+        }
+      } catch (Exception e) {
+        System.err.println("Error: " + e);
+      }
+      result.add(club);
     }
-    Gson gson = new Gson();
+    else {
+      ApiFuture<QuerySnapshot> future = clubs.get();
+      try {
+        List<QueryDocumentSnapshot> documents = future.get().getDocuments();
+        for (QueryDocumentSnapshot document : documents) {
+          result.add(document.toObject(Club.class));
+        }
+      } catch (Exception e) {
+        System.err.println("Error: " + e);
+      }
+    }
     response.setContentType("application/json;");
-    response.getWriter().println(gson.toJson(clubs));
+    response.getWriter().println(gson.toJson(result));
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    JsonObject jsonObject = createRequestBodyJson(request);
+    JsonObject jsonObject = Utility.createRequestBodyJson(request);
+    String id = jsonObject.get("id").getAsString();
     String name = jsonObject.get("name").getAsString();
-    String description = jsonObject.get("description").getAsString();
-    long ownerID = jsonObject.get("ownerID").getAsLong();
-
-    String announcement = "";
-    if (jsonObject.get("announcement") != null) {
-      announcement = jsonObject.get("announcement").getAsString();
-    }
-
-    Collection<Long> inviteIDs = new ArrayList<>();
-    if (jsonObject.get("inviteIDs") != null) {
-      for(JsonElement j : jsonObject.get("inviteIDs").getAsJsonArray()) {
-        inviteIDs.add(Long.parseLong(j.getAsString()));
-      } 
-    }
-
+    String ownerID = jsonObject.get("ownerID").getAsString();
+    String description = "";
     String gbookID = "";
+
+    if (jsonObject.get("description") != null) {
+      description = jsonObject.get("description").getAsString();
+    }
     if (jsonObject.get("gbookID") != null) {
       gbookID = jsonObject.get("gbookID").getAsString();
     }
 
-    Entity clubEntity = new Entity("Club");
-
-    clubEntity.setProperty("id", clubEntity.getKey().getId());
-    clubEntity.setProperty("name", name);
-    clubEntity.setProperty("description", description);
-    clubEntity.setProperty("announcement", announcement);
-    clubEntity.setProperty("posts" , new ArrayList<String>());
-    clubEntity.setProperty("ownerID", ownerID);
-    clubEntity.setProperty("inviteIDs", inviteIDs);
-    clubEntity.setProperty("memberIDs", new ArrayList<Long>());
-    clubEntity.setProperty("gbookID", gbookID);
-
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.put(clubEntity);
+    Club club = new Club(id, name, description, ownerID, gbookID);
+    ApiFuture<WriteResult> future = clubs.document(id).set(club);
+    try {
+      System.out.println("Update time : " + future.get().getUpdateTime());
+    } catch (Exception e) {
+      System.err.println("Error: " + e);
+    }
+    Gson gson = new Gson();
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(club));
   }
 
   @Override
   public void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    JsonObject jsonObject = createRequestBodyJson(request);
-    long id = jsonObject.get("id").getAsLong();
-    Entity clubEntity = new Entity("Club", id);
-
-    String name = (String) clubEntity.getProperty("name");
-    String description = (String) clubEntity.getProperty("description");
-    String announcement = (String) clubEntity.getProperty("announcement");
-    long ownerID = (long) clubEntity.getProperty("ownerID");
-    String gbookID = (String) clubEntity.getProperty("gbookID");
+    JsonObject jsonObject = Utility.createRequestBodyJson(request);
+    String id = jsonObject.get("id").getAsString();
+    Map<String, Object> update = new HashMap<>();
 
     if (jsonObject.get("name") != null) {
-      name = jsonObject.get("name").getAsString();
+      update.put("name", jsonObject.get("name").getAsString());
     }
     if (jsonObject.get("description") != null) {
-      description = jsonObject.get("description").getAsString();
-    }
-    if (jsonObject.get("announcement") != null) {
-      announcement = jsonObject.get("announcement").getAsString();
-    }
-    if (jsonObject.get("ownerID") != null) {
-      ownerID = jsonObject.get("ownerID").getAsLong();
+      update.put("description", jsonObject.get("description").getAsInt());
     }
     if (jsonObject.get("gbookID") != null) {
-      gbookID = jsonObject.get("gbookID").getAsString();
+      update.put("gbookID", jsonObject.get("gbookID").getAsString());
     }
 
-    clubEntity.setProperty("name", name);
-    clubEntity.setProperty("description", description);
-    clubEntity.setProperty("announcement", announcement);
-    clubEntity.setProperty("ownerID", ownerID);
-    clubEntity.setProperty("gbookID", gbookID);
-
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.put(clubEntity);
+    ApiFuture<WriteResult> writeResult = clubs.document(id).set(update, SetOptions.merge());
+    try {
+      System.out.println("Update time : " + writeResult.get().getUpdateTime());
+    } catch (Exception e) {
+      System.err.println("Error: " + e);
+    }
   }
 }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -103,7 +103,6 @@ public class ClubServlet extends HttpServlet {
     } catch (Exception e) {
       System.err.println("Error: " + e);
     }
-    Gson gson = new Gson();
     response.setContentType("application/json;");
     response.getWriter().println(gson.toJson(club));
   }

--- a/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,29 +29,29 @@ public final class ClubTest {
   private static final String POST_ONE = "postOne";
   private static final String POST_TWO = "postTwo";
 
-  private static final long ORIGINAL_OWNER = 1;
-  private static final long NEW_OWNER = 2;
+  private static final String ORIGINAL_OWNER = "originalOwner";
+  private static final String NEW_OWNER = "newOwner";
 
-  private static final long MEMBER_ONE = 1;
-  private static final long MEMBER_TWO = 2;
-  private static final long MEMBER_THREE = 3;
+  private static final String MEMBER_ONE = "memberOne";
+  private static final String MEMBER_TWO = "memberTwo";
+  private static final String MEMBER_THREE = "memberThree";
 
   private static final String ORIGINAL_BOOK = "originalBook";
   private static final String NEW_BOOK = "newBook";
 
   @Before
   public void setUp() {
-    club = new Club(1, ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
+    club = new Club("id", ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
   }
   
   @Test
   public void testConstructor() {
-    Assert.assertEquals(club.getID(), 1);
+    Assert.assertEquals(club.getID(), "id");
     Assert.assertEquals(club.getName(), ORIGINAL_NAME);
     Assert.assertEquals(club.getDescription(), ORIGINAL_DESCRIPTION);
     Assert.assertEquals(club.getAnnouncement(), "");
     Assert.assertEquals(club.getPosts().size(), 0);
-    Assert.assertEquals(club.getOwnerID(), 1);
+    Assert.assertEquals(club.getOwnerID(), ORIGINAL_OWNER);
     Assert.assertEquals(club.getMemberIDs().size(), 0);
     Assert.assertEquals(club.getInviteIDs().size(), 0);
     Assert.assertEquals(club.getGbookID(), ORIGINAL_BOOK);
@@ -114,25 +115,25 @@ public final class ClubTest {
     club.invite(MEMBER_ONE);
 
     Assert.assertEquals(club.getInviteIDs().size(), 1);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
 
     club.invite(MEMBER_TWO);
 
     Assert.assertEquals(club.getInviteIDs().size(), 2);
-    list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
-    Assert.assertEquals(list.get(1), new Long(MEMBER_TWO));
+    list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
+    Assert.assertTrue(list.contains(MEMBER_TWO));
   }
 
   @Test
   public void testInviteList() {
-    club.invite(new ArrayList<>(Arrays.asList(MEMBER_ONE, MEMBER_TWO)));
+    club.invite(Arrays.asList(MEMBER_ONE, MEMBER_TWO));
 
     Assert.assertEquals(club.getInviteIDs().size(), 2);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
-    Assert.assertEquals(list.get(1), new Long(MEMBER_TWO));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
+    Assert.assertTrue(list.contains(MEMBER_TWO));
   }
 
   @Test
@@ -142,18 +143,18 @@ public final class ClubTest {
     club.uninvite(MEMBER_TWO);
 
     Assert.assertEquals(club.getInviteIDs().size(), 1);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
   }
 
   @Test
   public void testUninviteList() {
-    club.invite(new ArrayList<>(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE)));
-    club.uninvite(new ArrayList<>(Arrays.asList(MEMBER_TWO, MEMBER_THREE)));
+    club.invite(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE));
+    club.uninvite(Arrays.asList(MEMBER_TWO, MEMBER_THREE));
 
     Assert.assertEquals(club.getInviteIDs().size(), 1);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
   }
 
   @Test
@@ -165,10 +166,10 @@ public final class ClubTest {
     Assert.assertEquals(b, true);
     Assert.assertEquals(club.getInviteIDs().size(), 1);
     Assert.assertEquals(club.getMemberIDs().size(), 1);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_TWO));
-    list = new ArrayList<>(club.getMemberIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_TWO));
+    list = club.getMemberIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
   }
 
   @Test
@@ -180,14 +181,14 @@ public final class ClubTest {
     Assert.assertEquals(b, false);
     Assert.assertEquals(club.getInviteIDs().size(), 2);
     Assert.assertEquals(club.getMemberIDs().size(), 0);
-    List<Long> list = new ArrayList<>(club.getInviteIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
-    Assert.assertEquals(list.get(1), new Long(MEMBER_TWO));
+    List<String> list = club.getInviteIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
+    Assert.assertTrue(list.contains(MEMBER_TWO));
   }
   
   @Test
   public void removeMember() {
-    club.invite(new ArrayList<>(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE)));
+    club.invite(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE));
     club.addMember(MEMBER_ONE);
     club.addMember(MEMBER_TWO);
     club.addMember(MEMBER_THREE);
@@ -197,25 +198,25 @@ public final class ClubTest {
     club.removeMember(MEMBER_TWO);
 
     Assert.assertEquals(club.getMemberIDs().size(), 2);
-    List<Long> list = new ArrayList<>(club.getMemberIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_ONE));
-    Assert.assertEquals(list.get(1), new Long(MEMBER_THREE));
+    List<String> list = club.getMemberIDs();
+    Assert.assertTrue(list.contains(MEMBER_ONE));
+    Assert.assertTrue(list.contains(MEMBER_THREE));
   }
 
   @Test
   public void removeMembers() {
-    club.invite(new ArrayList<>(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE)));
+    club.invite(Arrays.asList(MEMBER_ONE, MEMBER_TWO, MEMBER_THREE));
     club.addMember(MEMBER_ONE);
     club.addMember(MEMBER_TWO);
     club.addMember(MEMBER_THREE);
 
     Assert.assertEquals(club.getMemberIDs().size(), 3);
 
-    club.removeMembers(new ArrayList(Arrays.asList(MEMBER_ONE, MEMBER_TWO)));
+    club.removeMembers(Arrays.asList(MEMBER_ONE, MEMBER_TWO));
 
     Assert.assertEquals(club.getMemberIDs().size(), 1);
-    List<Long> list = new ArrayList<>(club.getMemberIDs());
-    Assert.assertEquals(list.get(0), new Long(MEMBER_THREE));
+    List<String> list = club.getMemberIDs();
+    Assert.assertTrue(list.contains(MEMBER_THREE));
   }
 
   @Test 

--- a/capstone-frontend/package-lock.json
+++ b/capstone-frontend/package-lock.json
@@ -2298,6 +2298,11 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -2450,6 +2455,14 @@
           "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.0.1.tgz",
           "integrity": "sha512-Qs6SqCLm63rd0kNVh+wO4XsWLU6kgfwwaPYsLiClWf0Tewkzsa6MvB21bespb8cz+ANS+2t3So1ge3gintzhlw=="
         }
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -3065,6 +3078,21 @@
         "dns-txt": "^2.0.2",
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+          "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        }
       }
     },
     "boolbase": {
@@ -4277,16 +4305,31 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+      "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
       "requires": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
         "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.2",
         "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
+        "object.assign": "^4.1.0",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "deep-is": {
@@ -4800,6 +4843,27 @@
         "object.assign": "^4.1.0",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "es-to-primitive": {
@@ -5799,6 +5863,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6727,6 +6796,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6734,6 +6808,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -6834,6 +6913,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6841,6 +6925,11 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-obj": {
       "version": "2.0.0",
@@ -6904,6 +6993,11 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
       "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
     },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -6930,10 +7024,31 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -13736,10 +13851,46 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "requires": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/capstone-frontend/package.json
+++ b/capstone-frontend/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "deep-equal": "^2.0.3",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",

--- a/capstone-frontend/src/components/ClubPage.jsx
+++ b/capstone-frontend/src/components/ClubPage.jsx
@@ -1,10 +1,27 @@
 import React, { Component } from 'react';
 
 class ClubPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      response: {}
+    }
+  }
+
+  fetchClubData = () => {
+    fetch(`/api/clubs?id=${this.props.match.params.id}`)
+        .then(response => response.json()).then(res => this.setState({response: res[0]}));
+  }
+
   render() {
+    this.fetchClubData();
     return (
       <div>
-        <div> {this.props.match.params.id} </div>
+        <div> Club Name: {this.state.response.name} </div>
+        <div> ID: {this.props.match.params.id} </div>
+        <div> Description: {this.state.response.description} </div>
+        <div> OwnerID: {this.state.response.ownerID} </div>
+        <div> GbookID: {this.state.response.gbookID} </div>
       </div>
     );
   }

--- a/capstone-frontend/src/components/ClubPage.jsx
+++ b/capstone-frontend/src/components/ClubPage.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+
 class ClubPage extends Component {
   constructor(props) {
     super(props);
@@ -17,8 +18,10 @@ class ClubPage extends Component {
     this.fetchClubData();
   }
 
-  componentDidUpdate() {
-    this.fetchClubData();
+  componentDidUpdate(prevProps) {
+    if (this.props.match.params.id !== prevProps.match.params.id) {
+      this.fetchClubData();
+    }
   }
 
   render() {

--- a/capstone-frontend/src/components/ClubPage.jsx
+++ b/capstone-frontend/src/components/ClubPage.jsx
@@ -4,24 +4,31 @@ class ClubPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      response: {}
+      club: {}
     }
   }
 
   fetchClubData = () => {
     fetch(`/api/clubs?id=${this.props.match.params.id}`)
-        .then(response => response.json()).then(res => this.setState({response: res[0]}));
+        .then(response => response.json()).then(res => this.setState({club: res[0]}));
+  }
+
+  componentDidMount() {
+    this.fetchClubData();
+  }
+
+  componentDidUpdate() {
+    this.fetchClubData();
   }
 
   render() {
-    this.fetchClubData();
     return (
       <div>
-        <div> Club Name: {this.state.response.name} </div>
+        <div> Club Name: {this.state.club.name} </div>
         <div> ID: {this.props.match.params.id} </div>
-        <div> Description: {this.state.response.description} </div>
-        <div> OwnerID: {this.state.response.ownerID} </div>
-        <div> GbookID: {this.state.response.gbookID} </div>
+        <div> Description: {this.state.club.description} </div>
+        <div> OwnerID: {this.state.club.ownerID} </div>
+        <div> GbookID: {this.state.club.gbookID} </div>
       </div>
     );
   }


### PR DESCRIPTION
This PR re-creates backend functionality to get either all clubs or a club by its id, to post a club and to update a club via a put request. Before, this functionality was implemented using Google Cloud Datastore. This PR creates this same functionality (and adds filtering by ID) in Firebase. For now, this only supports basic club fields (eg. not memberIDs, inviteIDs or posts, all of which are Lists). 

The Collections and Sets in the Club.java class had to be changed to Lists as Firebase does not support Collections or Sets (https://github.com/firebase/firebase-admin-java/issues/78). Firebase essentially only supports storing maps, but can store Lists by mapping indices to their values. For example it would store Arrays.asList("foo", "bar") as:
```
{
  "1": "foo"
  "2": "bar"
}
```
However, since Collections and Sets are inherently unordered, it cannot serialize these the way it can Lists. This is explained in the above linked issue from the Firebase repository. Additionally, IDs were changed from Longs to Strings for Firebase support. The appropriate testing was similarly updated. 

The ClubPage component now performs its own fetch to get club data, using the ID to get a Club from the backend. It displays this data in a very basic form (see screenshot below for an example using some test data).

![Screenshot 2020-07-01 at 12 54 05 AM - Display 1](https://user-images.githubusercontent.com/43327083/86204792-5b24fc00-bb36-11ea-8cf2-30c7eae57a01.png)
