### PR TITLE
Generalized get method

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/data/BaseEntity.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/BaseEntity.java
@@ -1,0 +1,13 @@
+package com.google.sps.data;
+
+public class BaseEntity {
+  private String id;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+}

--- a/capstone-backend/src/main/java/com/google/sps/data/Club.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Club.java
@@ -2,7 +2,6 @@ package com.google.sps.data;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 
 public class Club extends BaseEntity {

--- a/capstone-backend/src/main/java/com/google/sps/data/Club.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Club.java
@@ -2,11 +2,12 @@ package com.google.sps.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 
 public class Club {
   
-  private final String id;
+  private final String id = UUID.randomUUID().toString();
   private String name;
   private String description;
   private String announcement;
@@ -16,9 +17,8 @@ public class Club {
   private List<String> inviteIDs;
   private String gbookID;
 
-  public Club(String id, String name, String description, String announcement, List<String> posts, 
+  public Club(String name, String description, String announcement, List<String> posts, 
       String ownerID, List<String> memberIDs, List<String> inviteIDs, String gbookID) {
-        this.id = id;
         this.name = name;
         this.description = description;
         this.announcement = announcement;
@@ -29,20 +29,20 @@ public class Club {
         this.gbookID = gbookID;
   }
 
-  public Club(String id, String name, String description, String ownerID, String gbookID){
-    this(id, name, description, "", new ArrayList<String>(), ownerID, new ArrayList<String>(), new ArrayList<String>(), gbookID);
+  public Club(String name, String description, String ownerID, String gbookID){
+    this(name, description, "", new ArrayList<String>(), ownerID, new ArrayList<String>(), new ArrayList<String>(), gbookID);
   }
 
-  public Club(String id, String name, String ownerID, String gbookID) {
-    this(id, name, "", ownerID, gbookID);
+  public Club(String name, String ownerID, String gbookID) {
+    this(name, "", ownerID, gbookID);
   }
 
-  public Club(String id, String name, String ownerID) {
-    this(id, name, "", ownerID, "");
+  public Club(String name, String ownerID) {
+    this(name, "", ownerID, "");
   }
 
   public Club() {
-    this("", "", "");
+    this("", "");
   }
  
   public String getID() {

--- a/capstone-backend/src/main/java/com/google/sps/data/Club.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Club.java
@@ -5,9 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 
-public class Club {
+public class Club extends BaseEntity {
   
-  private final String id = UUID.randomUUID().toString();
   private String name;
   private String description;
   private String announcement;
@@ -43,10 +42,6 @@ public class Club {
 
   public Club() {
     this("", "");
-  }
- 
-  public String getID() {
-    return this.id;
   }
  
   public String getName() {

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -47,35 +47,7 @@ public class ClubServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<Club> result = new ArrayList<>();
-    if (request.getParameter("id") != null) {
-      DocumentReference docRef = clubs.document(request.getParameter("id"));
-      ApiFuture<DocumentSnapshot> future = docRef.get();
-      DocumentSnapshot document = null;
-      Club club = null;
-      try {
-        document = future.get();
-        if (document.exists()) {
-          club = document.toObject(Club.class);
-        } else {
-          System.err.println("Error: no such document!");
-        }
-      } catch (Exception e) {
-        System.err.println("Error: " + e);
-      }
-      result.add(club);
-    }
-    else {
-      ApiFuture<QuerySnapshot> future = clubs.get();
-      try {
-        List<QueryDocumentSnapshot> documents = future.get().getDocuments();
-        for (QueryDocumentSnapshot document : documents) {
-          result.add(document.toObject(Club.class));
-        }
-      } catch (Exception e) {
-        System.err.println("Error: " + e);
-      }
-    }
+    List<Club> result = Utility.get(clubs, request, new GenericClass(Club.class));
     response.setContentType("application/json;");
     response.getWriter().println(gson.toJson(result));
   }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -43,41 +43,7 @@ public class ClubServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<Club> clubsRetrieved = new ArrayList<>();
-    if (request.getParameter("id") != null) {
-      DocumentReference docRef = clubs.document(request.getParameter("id"));
-      ApiFuture<DocumentSnapshot> asyncDocument = docRef.get();
-      DocumentSnapshot document = null;
-      Club club = null;
-      try {
-        document = asyncDocument.get();
-        if (document.exists()) {
-          club = document.toObject(Club.class);
-        } else {
-          System.err.println("Error: no such document!");
-          response.sendError(HttpServletResponse.SC_NOT_FOUND);
-          return;
-        }
-      } catch (Exception e) {
-        System.err.println("Error: " + e);
-        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        return;
-      }
-      clubsRetrieved.add(club);
-    }
-    else {
-      ApiFuture<QuerySnapshot> asyncDocument = clubs.get();
-      try {
-        List<QueryDocumentSnapshot> documents = asyncDocument.get().getDocuments();
-        for (QueryDocumentSnapshot document : documents) {
-          clubsRetrieved.add(document.toObject(Club.class));
-        }
-      } catch (Exception e) {
-        System.err.println("Error: " + e);
-        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        return;
-      }
-    }
+    List<Club> result = Utility.get(clubs, request, new GenericClass(Club.class));
     response.setContentType("application/json;");
     response.getWriter().println(gson.toJson(clubsRetrieved));
   }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -43,9 +43,11 @@ public class ClubServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<Club> result = Utility.get(clubs, request, new GenericClass(Club.class));
-    response.setContentType("application/json;");
-    response.getWriter().println(gson.toJson(clubsRetrieved));
+    List<Club> retrievedClubs = Utility.get(clubs, request, response, new GenericClass(Club.class));
+    if (retrievedClubs != null) {
+      response.setContentType("application/json;");
+      response.getWriter().println(gson.toJson(retrievedClubs));
+    }
   }
 
   @Override

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -66,7 +66,7 @@ public class ClubServlet extends HttpServlet {
       gbookID = jsonObject.get("gbookID").getAsString();
     }
 
-    Club club = new Club(id, name, description, ownerID, gbookID);
+    Club club = new Club(name, description, ownerID, gbookID);
     ApiFuture<WriteResult> asyncDocument = clubs.document(id).set(club);
     try {
       System.out.println("Update time : " + asyncDocument.get().getUpdateTime());

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -47,9 +47,11 @@ public class ClubServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<Club> result = Utility.get(clubs, request, new GenericClass(Club.class));
-    response.setContentType("application/json;");
-    response.getWriter().println(gson.toJson(result));
+    List<Club> retrievedClubs = Utility.get(clubs, request, response, new GenericClass(Club.class));
+    if (retrievedClubs != null) {
+      response.setContentType("application/json;");
+      response.getWriter().println(gson.toJson(retrievedClubs));
+    }
   }
 
   @Override

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -70,7 +70,7 @@ public class ClubServlet extends HttpServlet {
       gbookID = jsonObject.get("gbookID").getAsString();
     }
 
-    Club club = new Club(id, name, description, ownerID, gbookID);
+    Club club = new Club(name, description, ownerID, gbookID);
     ApiFuture<WriteResult> future = clubs.document(id).set(club);
     try {
       System.out.println("Update time : " + future.get().getUpdateTime());

--- a/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/ClubServlet.java
@@ -14,15 +14,11 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import com.google.sps.data.Club;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;

--- a/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
@@ -3,7 +3,6 @@ package com.google.sps.servlets;
 public class GenericClass<T> {
 
   private final Class<T> type;
-  private String id;
 
   public GenericClass(Class<T> type) {
     this.type = type;

--- a/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
@@ -2,13 +2,14 @@ package com.google.sps.servlets;
 
 public class GenericClass<T> {
 
-     private final Class<T> type;
+  private final Class<T> type;
+  private String id;
 
-     public GenericClass(Class<T> type) {
-          this.type = type;
-     }
+  public GenericClass(Class<T> type) {
+    this.type = type;
+  }
 
-     public Class<T> getMyType() {
-         return this.type;
-     }
+  public Class<T> getMyType() {
+   return this.type;
+  }
 }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/GenericClass.java
@@ -1,0 +1,14 @@
+package com.google.sps.servlets;
+
+public class GenericClass<T> {
+
+     private final Class<T> type;
+
+     public GenericClass(Class<T> type) {
+          this.type = type;
+     }
+
+     public Class<T> getMyType() {
+         return this.type;
+     }
+}

--- a/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
@@ -66,6 +66,14 @@ public class Utility {
     return jsonObject;
   }
 
+  /**
+   * Query the given collection by id. 
+   * @param {collectionReference} reference to the appropriate database collection
+   * @param {request} request sent to the backend
+   * @param {response} response returned from the call
+   * @param {genericClass} a Generic class, used in casting documents from the database
+   * @return List<T> a singleton List of the Object that matches the ID in the request.
+   */
   private static <T> List<T> getById(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     if (request.getParameterMap().size() > 1) {
@@ -97,6 +105,14 @@ public class Utility {
     return retrievedObjects;
   }
 
+  /**
+   * Appends filters to the given query depending on fields in the request query 
+   * @param {genericClass} a Generic class, used in casting documents from the database
+   * @param {response} response returned from the call
+   * @param {it} iterator for the Map of query parameter names to values
+   * @param {query} query being modified, to eventually be used to query the database.
+   * @return Query the query being modified, to eventually be used to query the database.
+   */
   private static <T> Query addToQuery(GenericClass<T> genericClass, HttpServletResponse response, 
       Iterator it, Query query) throws IOException {
     Map.Entry<String, String[]> entry = (Map.Entry) it.next();
@@ -136,6 +152,14 @@ public class Utility {
     }
   }
 
+  /**
+   * Gets an asynchronous collection of matching documents from the database matching the request
+   * @param {collectionRefence} reference to the appropriate collection of documents in the database
+   * @param {genericClass} a Generic class, used in casting documents from the database
+   * @param {request} request sent to the backend
+   * @param {response} response returned from the call
+   * @return Query the query being modified, to eventually be used to query the database.
+   */
   private static <T> ApiFuture<QuerySnapshot> getByField(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     Iterator it = request.getParameterMap().entrySet().iterator();
@@ -179,6 +203,17 @@ public class Utility {
     return query.get();
   }
 
+  /**
+   * Performs a get request on the given collection, allowing the requester to apply any number 
+   * of queries both for equality and to check membership in list fields. Query parameters must 
+   * match object field names exactly. If no queries are applied, the entire collection
+   * is returned. If an ID is supplied, a singleton list with that object is returned. 
+   * @param {collectionRefence} the appropriate collection of documents in the database
+   * @param {request} the request sent to the backend
+   * @param {response} the response returned from the call
+   * @param {genericClass} a Generic class, to be used in casting objects retrieved from the database
+   * @return Query the query being modified, to eventually be used to query the database.
+   */
   public static <T> List<T> get(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     List<T> retrievedObjects = new ArrayList<>();

--- a/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
@@ -21,6 +21,8 @@ import com.google.gson.JsonParser;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -58,4 +60,38 @@ public class Utility {
     }
     return jsonObject;
   }
+
+  public static <T> List<T> get(CollectionReference collectionReference, HttpServletRequest request, GenericClass<T> genClass) throws IOException {
+    List<T> result = new ArrayList<>();
+    if (request.getParameter("id") != null) {
+      DocumentReference docRef = collectionReference.document(request.getParameter("id"));
+      ApiFuture<DocumentSnapshot> future = docRef.get();
+      DocumentSnapshot document = null;
+      T item = null;
+      try {
+        document = future.get();
+        if (document.exists()) {
+          item = document.toObject(genClass.getMyType());
+        } else {
+          System.err.println("Error: no such document!");
+        }
+      } catch (Exception e) {
+        System.err.println("Error: " + e);
+      }
+      result.add(item);
+    }
+    else {
+      ApiFuture<QuerySnapshot> future = collectionReference.get();
+      try {
+        List<QueryDocumentSnapshot> documents = future.get().getDocuments();
+        for (QueryDocumentSnapshot document : documents) {
+          result.add(document.toObject(genClass.getMyType()));
+        }
+      } catch (Exception e) {
+        System.err.println("Error: " + e);
+      }
+    }
+    return result;
+  }
+
 }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
@@ -138,14 +138,19 @@ public class Utility {
   /**
    * Gets an asynchronous collection of matching documents from the database matching the request
    * @param {collectionRefence} reference to the appropriate collection of documents in the database
-   * @param {genericClass} a Generic class, used in casting documents from the database
    * @param {request} request sent to the backend
    * @param {response} response returned from the call
-   * @return Query the query being modified, to eventually be used to query the database.
+   * @param {genericClass} a Generic class, used in casting documents from the database
+   * @return ApiFuture<QuerySnapshot> the asynchronous query results from the given filters.
    */
   private static <T> ApiFuture<QuerySnapshot> getByField(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     Iterator<Map.Entry<String, String[]>> it = request.getParameterMap().entrySet().iterator();
+    if (!it.hasNext()) {
+      System.err.println("Error in iterating through the request query map");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      return null;
+    }
     Map.Entry<String, String[]> entry = it.next();
     String parameterName = entry.getKey();
     if (entry.getValue().length != 1) {
@@ -214,10 +219,9 @@ public class Utility {
       }
     }
     try {
-      List<QueryDocumentSnapshot> documents = asyncQuery.get().getDocuments();
-      for (QueryDocumentSnapshot document : documents) {
-        retrievedObjects.add(document.toObject(genericClass.getMyType()));
-      }
+      retrievedObjects = asyncQuery.get().getDocuments().stream()
+                             .map(d -> d.toObject(genericClass.getMyType()))
+                             .collect(Collectors.toList());
     } catch (Exception e) {
       System.err.println("Error: " + e);
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/Utility.java
@@ -19,6 +19,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import com.google.sps.data.BaseEntity;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
@@ -58,7 +60,7 @@ public class Utility {
    * @param {genericClass} a Generic class, used in casting documents from the database
    * @return List<T> a singleton List of the Object that matches the ID in the request.
    */
-  private static <T> List<T> getById(CollectionReference collectionReference, HttpServletRequest request, 
+  private static <T extends BaseEntity> List<T> getById(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     if (request.getParameterMap().size() > 1) {
       System.err.println("Error: No other parameter can be sent with an ID");
@@ -74,6 +76,7 @@ public class Utility {
       document = asyncDocument.get();
       if (document.exists()) {
         item = document.toObject(genericClass.getMyType());
+        item.setId(document.getId());
       } else {
         System.err.println("Error: no such document!");
         response.sendError(HttpServletResponse.SC_NOT_FOUND);
@@ -96,7 +99,7 @@ public class Utility {
    * @param {query} query being modified, to eventually be used to query the database.
    * @return Query the query being modified, to eventually be used to query the database.
    */
-  private static <T> Query addToQuery(GenericClass<T> genericClass, HttpServletResponse response, 
+  private static <T extends BaseEntity> Query addToQuery(GenericClass<T> genericClass, HttpServletResponse response, 
       Iterator<Map.Entry<String, String[]>> it, Query query) throws IOException {
     Map.Entry<String, String[]> entry = it.next();
     String parameterName = entry.getKey();
@@ -143,7 +146,7 @@ public class Utility {
    * @param {genericClass} a Generic class, used in casting documents from the database
    * @return ApiFuture<QuerySnapshot> the asynchronous query results from the given filters.
    */
-  private static <T> ApiFuture<QuerySnapshot> getByField(CollectionReference collectionReference, HttpServletRequest request, 
+  private static <T extends BaseEntity> ApiFuture<QuerySnapshot> getByField(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     Iterator<Map.Entry<String, String[]>> it = request.getParameterMap().entrySet().iterator();
     if (!it.hasNext()) {
@@ -202,7 +205,7 @@ public class Utility {
    * @param {genericClass} a Generic class, to be used in casting objects retrieved from the database
    * @return Query the query being modified, to eventually be used to query the database.
    */
-  public static <T> List<T> get(CollectionReference collectionReference, HttpServletRequest request, 
+  public static <T extends BaseEntity> List<T> get(CollectionReference collectionReference, HttpServletRequest request, 
       HttpServletResponse response, GenericClass<T> genericClass) throws IOException {
     List<T> retrievedObjects = new ArrayList<>();
     ApiFuture<QuerySnapshot> asyncQuery;
@@ -220,7 +223,11 @@ public class Utility {
     }
     try {
       retrievedObjects = asyncQuery.get().getDocuments().stream()
-                             .map(d -> d.toObject(genericClass.getMyType()))
+                             .map(d -> {
+                                        T t = d.toObject(genericClass.getMyType());
+                                        t.setId(d.getId());
+                                        return t;
+                                       })
                              .collect(Collectors.toList());
     } catch (Exception e) {
       System.err.println("Error: " + e);

--- a/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
@@ -1,15 +1,11 @@
 package com.google.sps.data;
 
-import com.google.sps.data.Club;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
@@ -37,12 +37,11 @@ public final class ClubTest {
 
   @Before
   public void setUp() {
-    club = new Club("id", ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
+    club = new Club(ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
   }
   
   @Test
   public void testConstructor() {
-    Assert.assertEquals(club.getID(), "id");
     Assert.assertEquals(club.getName(), ORIGINAL_NAME);
     Assert.assertEquals(club.getDescription(), ORIGINAL_DESCRIPTION);
     Assert.assertEquals(club.getAnnouncement(), "");

--- a/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
@@ -41,12 +41,11 @@ public final class ClubTest {
 
   @Before
   public void setUp() {
-    club = new Club("id", ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
+    club = new Club(ORIGINAL_NAME, ORIGINAL_DESCRIPTION, ORIGINAL_OWNER, ORIGINAL_BOOK);
   }
   
   @Test
   public void testConstructor() {
-    Assert.assertEquals(club.getID(), "id");
     Assert.assertEquals(club.getName(), ORIGINAL_NAME);
     Assert.assertEquals(club.getDescription(), ORIGINAL_DESCRIPTION);
     Assert.assertEquals(club.getAnnouncement(), "");

--- a/capstone-frontend/package.json
+++ b/capstone-frontend/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "deep-equal": "^2.0.3",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
This PR creates a generalized `get()` method in the Utility class for all servlets to use in the future. 
* It allows the requester to apply any number of queries both for equality in primitive type and string classes, and membership in object fields of type `List` or `ArrayList`. Query parameters must match object field names exactly, or errors will be thrown and a null `List` will be returned. Reflection and the `Field` class and methods are used to achieve this. 
* If no queries are applied, the entire collection of documents is returned. 
* If a valid ID is supplied, a singleton list with the matching object is returned, if no object is found errors will be thrown and a null `List` will be returned. 

It will cast the retrieved documents to be objects of the given Class. `GenericClass` and the built in Java generic type are used for this purpose, allowing retrieval of object type at runtime. 

All servlets can call the generalized `get()` method to perform queries for equality or membership on any field of any object class. The method performs all necessary error handling (on errors, bad requests, or when an id is not found), the method will attach response headers of 400, 404 and 500 appropriately, and return a null List<T>). Servlets should call this method, and print its results to the HttpServletResponse. 

## Example Use
* `/api/clubs?name=example%20name` will filter for all clubs with the name "example name" 
* `/api/clubs?memberIDs=member1` will filter for all clubs where "member1" is a memberID of a club member
* `/api/clubs/?name=example%20name&memberIDs=member1` will filter for all clubs with the name "example name" and where "member1" is a memberID of a club member
* `/api/clubs?id=exampleID` will return a singleton list with the club whose id is "exampleID"
* `/api/clubs` will return all clubs