### PR TITLE
Search Servlet Add Search by Id

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/data/VolumeData.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/VolumeData.java
@@ -6,39 +6,58 @@ package com.google.sps.data;
  * Note: The private variables in this class are converted into JSON.
  */
 public final class VolumeData {
-    
+
   private final String id;
   private final String title;
   private final String[] authors;
   private final String description;
+  private final double avgRating;
+  private final String canonicalVolumeLink;
   private final String thumbnailLink;
- 
+  private final String webReaderLink;
+
   /** Constructor for a VolumeData Object */
-  public VolumeData(String id, String title, String[] authors, String description, String thumbnailLink){
+  public VolumeData(String id, String title, String[] authors, String description, double avgRating,
+      String canonicalVolumeLink, String thumbnailLink, String webReaderLink) {
     this.id = id;
     this.title = title;
     this.authors = authors;
     this.description = description;
+    this.avgRating = avgRating;
     this.thumbnailLink = thumbnailLink;
+    this.canonicalVolumeLink = canonicalVolumeLink;
+    this.webReaderLink = webReaderLink;
   }
 
   public String getID() {
     return id;
   }
- 
+
   public String getTitle() {
     return this.title;
   }
- 
+
   public String[] getAuthors() {
     return this.authors;
   }
- 
+
   public String getDescription() {
     return this.description;
   }
 
+  public double getAvgRating() {
+    return this.avgRating;
+  }
+
+  public String getCanonicalVolumeLink() {
+    return this.canonicalVolumeLink;
+  }
+
   public String getThumbnailLink() {
     return this.thumbnailLink;
+  }
+
+  public String getWebReaderLink() {
+    return this.webReaderLink;
   }
 }

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -59,7 +59,7 @@ public class SearchServlet extends HttpServlet {
       formattedURL = String.format("https://www.googleapis.com/books/v1/volumes/%s", gbookId);
 
     } else if (request.getParameter("searchTerm") != null || !request.getParameter("searchTerm").isEmpty()) {
-      if (request.getParameterMap().size() >= 2 && request.getParameter("maxResults") != null) {
+      if (request.getParameterMap().size() >= 2 && request.getParameter("maxResults") == null) {
         System.err.println("Error: No other parameters must be sent with searchTerm other than maxResults");
         response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         return;

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -31,7 +31,6 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Collectors;
-
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -58,7 +58,7 @@ public class SearchServlet extends HttpServlet {
       String gbookId = request.getParameter("gbookId");
       formattedURL = String.format("https://www.googleapis.com/books/v1/volumes/%s", gbookId);
 
-    } else if (request.getParameter("searchTerm") != null || request.getParameter("searchTerm").isEmpty()) {
+    } else if (request.getParameter("searchTerm") != null || !request.getParameter("searchTerm").isEmpty()) {
       String searchTerm = URLEncoder.encode(request.getParameter("searchTerm"), "UTF-8");
       // format url
       int maxResults = DEFAULT_MAX_RESULTS;

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -26,11 +26,12 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Collectors;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -45,29 +46,42 @@ public class SearchServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-    // response.setHeader("Access-Control-Allow-Methods", "GET");
-    // response.setHeader("Access-Control-Allow-Credentials", "true");
-    // response.setHeader("Access-Control-Allow-Origin",
-    //     "https://3000-bbaec244-5a54-4467-aed6-91c386e88c1a.ws-us02.gitpod.io");
-
     String fullOutput = "";
-    String searchTerm = request.getParameter("searchTerm");
-    if (searchTerm == null || searchTerm.isEmpty())
-      return;
-    searchTerm = URLEncoder.encode(searchTerm, "UTF-8");
+    String formattedURL = "";
 
-    int maxResults = 0;
-    String maxResultsParam = request.getParameter("maxResults"); 
-    if (maxResultsParam != null) { 
-      maxResults = parseNaturalNumber(maxResultsParam);
-    }
-    if (maxResultsParam == null || maxResults == -1) {
-      maxResults = DEFAULT_MAX_RESULTS;
+    if (request.getParameter("gbookId") != null) {
+      if (request.getParameterMap().size() > 1) {
+        System.err.println("Error: No other parameter can be sent with a gbookId");
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+      // make formatted url
+      String gbookId = request.getParameter("gbookId");
+      formattedURL = String.format("https://www.googleapis.com/books/v1/volumes/%s", gbookId);
+
+    } else if (request.getParameter("searchTerm") != null || request.getParameter("searchTerm").isEmpty()) {
+      String searchTerm = URLEncoder.encode(request.getParameter("searchTerm"), "UTF-8");
+      // format url
+      int maxResults = DEFAULT_MAX_RESULTS;
+      String maxResultsParam = request.getParameter("maxResults");
+      // If maxResultsParam represents a positive integer,
+      // then replace maxResults with the new value
+      if (maxResultsParam != null) {
+        int parsedMaxResults = parseNaturalNumber(maxResultsParam);
+        if (parsedMaxResults != -1) {
+          maxResults = parsedMaxResults;
+        }
+      }
+      formattedURL = String.format("https://www.googleapis.com/books/v1/volumes?q={%s}&maxResults=%d&country=US",
+          searchTerm, maxResults);
+
+    } else {
+      System.err.println("Error: Invalid combination of parameters sent");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      return;
     }
 
     try {
-      String formattedURL = String.format("https://www.googleapis.com/books/v1/volumes?q={%s}&maxResults=%d&country=US",
-          searchTerm, maxResults);
       URL url = new URL(formattedURL);
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("GET");
@@ -81,27 +95,42 @@ public class SearchServlet extends HttpServlet {
       }
       BufferedReader br = new BufferedReader(streamReader);
 
-      String output;
-      while ((output = br.readLine()) != null) {
-        fullOutput += output;
-      }
+      fullOutput = br.lines().collect(Collectors.joining());
 
       if (conn.getResponseCode() != 200) {
         System.err.println(fullOutput);
-        throw new RuntimeException("Failed : error code : " + conn.getResponseCode());
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        return;
       }
 
       conn.disconnect();
-    } catch (MalformedURLException e) {
+    } catch (Exception e) {
       e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
     }
 
     response.setContentType("application/json;");
-    Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
-    response.getWriter().println(gson.toJson(convertResponseToVolumeData(fullOutput)));
+    Collection<VolumeData> volumes = new ArrayList<>();
+    if (request.getParameter("gbookId") != null) {
+      VolumeData bookObject = individualBookToVolumeData(JsonParser.parseString(fullOutput));
+      if (bookObject != null) {
+        volumes.add(bookObject);
+      } else {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        return;
+      }
+    } else if (request.getParameter("searchTerm") != null) {
+      volumes.addAll(convertResponseToVolumeData(fullOutput));
+      if (volumes.size() == 0) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        return;
+      }
+    }
+
+    Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    response.getWriter().println(gson.toJson(volumes));
   }
 
   /*
@@ -125,41 +154,67 @@ public class SearchServlet extends HttpServlet {
     JsonArray itemsInfo = items.getAsJsonArray();
 
     for (JsonElement book : itemsInfo) {
-      JsonObject bookInfo = book.getAsJsonObject();
-      String id = bookInfo.get("id").getAsString();
-
-      // volumeInfo houses all of the information about the book itself: description,
-      // authors, title
-      JsonElement volumeInfo = bookInfo.get("volumeInfo");
-      if (volumeInfo == null)
-        continue;
-      JsonObject volumeInfoObj = volumeInfo.getAsJsonObject();
-
-      JsonElement titleElement = volumeInfoObj.get("title");
-      String title = titleElement != null ? titleElement.getAsString() : "";
-
-      // there may be any number of authors, not guaranteed to only have 1
-      JsonElement authors = volumeInfoObj.get("authors");
-      ArrayList<String> authorNames = new ArrayList<>();
-      if (authors != null) {
-        JsonArray authorsArray = authors.getAsJsonArray();
-        for (JsonElement name : authorsArray) {
-          authorNames.add(name.getAsString());
-        }
+      VolumeData bookObject = individualBookToVolumeData(book);
+      if (bookObject != null) {
+        volumes.add(individualBookToVolumeData(book));
       }
-
-      JsonElement descElement = volumeInfoObj.get("description");
-      String description = descElement != null ? descElement.getAsString() : "";
-
-      JsonElement thumbnailElement = volumeInfoObj.get("imageLinks");
-      String thumbnailLink = thumbnailElement != null
-          ? thumbnailElement.getAsJsonObject().get("thumbnail").getAsString()
-          : "";
-      thumbnailLink = thumbnailLink.replace("http", "https");
-
-      volumes.add(new VolumeData(id, title, authorNames.toArray(new String[0]), description, thumbnailLink));
     }
     return volumes;
+  }
+
+  /*
+   * Takes in an individual book response from the Google Books API and converts
+   * it to a VolumeData object.
+   * 
+   * @param singleBook a single book from the Books API as a JsonElement
+   * 
+   * @return a singular object of the book from the API call
+   */
+  static VolumeData individualBookToVolumeData(JsonElement singleBook) {
+    JsonObject bookInfo = singleBook.getAsJsonObject();
+    String id = bookInfo.get("id").getAsString();
+
+    // volumeInfo houses all of the information about the book itself: description,
+    // authors, title
+    JsonElement volumeInfo = bookInfo.get("volumeInfo");
+    if (volumeInfo == null)
+      return null;
+    JsonObject volumeInfoObj = volumeInfo.getAsJsonObject();
+
+    JsonElement titleElement = volumeInfoObj.get("title");
+    String title = titleElement != null ? titleElement.getAsString() : "";
+
+    // there may be any number of authors, not guaranteed to only have 1
+    JsonElement authors = volumeInfoObj.get("authors");
+    ArrayList<String> authorNames = new ArrayList<>();
+    if (authors != null) {
+      JsonArray authorsArray = authors.getAsJsonArray();
+      for (JsonElement name : authorsArray) {
+        authorNames.add(name.getAsString());
+      }
+    }
+
+    JsonElement descElement = volumeInfoObj.get("description");
+    String description = descElement != null ? descElement.getAsString() : "";
+
+    JsonElement avgRatingElement = volumeInfoObj.get("averageRating");
+    double avgRating = avgRatingElement != null ? avgRatingElement.getAsDouble() : -1;
+
+    JsonElement canonVolumeElement = volumeInfoObj.get("canonicalVolumeLink");
+    String canonicalVolumeLink = canonVolumeElement != null ? canonVolumeElement.getAsString() : "";
+
+    JsonElement thumbnailElement = volumeInfoObj.get("imageLinks");
+    String thumbnailLink = thumbnailElement != null ? thumbnailElement.getAsJsonObject().get("thumbnail").getAsString()
+        : "";
+    thumbnailLink = thumbnailLink.replace("http", "https");
+
+    JsonElement accessInfoElement = bookInfo.get("accessInfo");
+    String webReaderLink = accessInfoElement != null
+        ? accessInfoElement.getAsJsonObject().get("webReaderLink").getAsString()
+        : "";
+
+    return new VolumeData(id, title, authorNames.toArray(new String[0]), description, avgRating, canonicalVolumeLink,
+        thumbnailLink, webReaderLink);
   }
 
   /*

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -59,7 +59,8 @@ public class SearchServlet extends HttpServlet {
       formattedURL = String.format("https://www.googleapis.com/books/v1/volumes/%s", gbookId);
 
     } else if (request.getParameter("searchTerm") != null || !request.getParameter("searchTerm").isEmpty()) {
-      if (request.getParameterMap().size() >= 2 && request.getParameter("maxResults") == null) {
+      int parameterLength = request.getParameterMap().size();
+      if ((parameterLength == 2 && request.getParameter("maxResults") == null) || parameterLength > 2) {
         System.err.println("Error: No other parameters must be sent with searchTerm other than maxResults");
         response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         return;

--- a/capstone-backend/src/test/java/com/google/sps/data/VolumeDataTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/VolumeDataTest.java
@@ -17,26 +17,38 @@ public final class VolumeDataTest {
   private static final String[] AUTHORS_1 = { "Andy", "Robert" };
   private static final String[] AUTHORS_2 = {};
   private static final String DESCRIPTION = "desc";
+  private static final double AVERAGE_RATING = 3.5;
+  private static final String CANONICAL_VOLUME_LINK = "canonlink.com";
   private static final String THUMBNAIL_LINK = "google.com";
+  private static final String WEB_READER_LINK = "webreaderlink.com";
 
   @Before
   public void setUp() {
-    volumeOne = new VolumeData(ID, TITLE, AUTHORS_1, DESCRIPTION, THUMBNAIL_LINK);
-    volumeTwo = new VolumeData(ID, TITLE, AUTHORS_2, DESCRIPTION, THUMBNAIL_LINK);
+    volumeOne = new VolumeData(ID, TITLE, AUTHORS_1, DESCRIPTION, AVERAGE_RATING, CANONICAL_VOLUME_LINK, THUMBNAIL_LINK,
+        WEB_READER_LINK);
+    volumeTwo = new VolumeData(ID, TITLE, AUTHORS_2, DESCRIPTION, AVERAGE_RATING, CANONICAL_VOLUME_LINK, THUMBNAIL_LINK,
+        WEB_READER_LINK);
   }
-  
+
   @Test
   public void testConstructor() {
     Assert.assertEquals(volumeOne.getID(), ID);
     Assert.assertEquals(volumeOne.getTitle(), TITLE);
     Assert.assertArrayEquals(volumeOne.getAuthors(), AUTHORS_1);
     Assert.assertEquals(volumeOne.getDescription(), DESCRIPTION);
+    Assert.assertEquals(volumeOne.getAvgRating(), AVERAGE_RATING, 0);
+    Assert.assertEquals(volumeOne.getCanonicalVolumeLink(), CANONICAL_VOLUME_LINK);
     Assert.assertEquals(volumeOne.getThumbnailLink(), THUMBNAIL_LINK);
-    
+    Assert.assertEquals(volumeOne.getWebReaderLink(), WEB_READER_LINK);
+
+
     Assert.assertEquals(volumeTwo.getID(), ID);
     Assert.assertEquals(volumeTwo.getTitle(), TITLE);
     Assert.assertArrayEquals(volumeTwo.getAuthors(), AUTHORS_2);
     Assert.assertEquals(volumeTwo.getDescription(), DESCRIPTION);
+    Assert.assertEquals(volumeTwo.getAvgRating(), AVERAGE_RATING, 0);
+    Assert.assertEquals(volumeTwo.getCanonicalVolumeLink(), CANONICAL_VOLUME_LINK);
     Assert.assertEquals(volumeTwo.getThumbnailLink(), THUMBNAIL_LINK);
+    Assert.assertEquals(volumeTwo.getWebReaderLink(), WEB_READER_LINK);
   }
 }

--- a/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
@@ -10,7 +10,6 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import static org.mockito.Mockito.when;
@@ -96,10 +95,17 @@ public class SearchServletTest {
     return result;
   }
 
+  /**
+   * Checks whether all fields in VolumeData are their default values. If there
+   * are any default values, return false.
+   * 
+   * @param book the VolumeData object
+   * @return false if any default values
+   */
   public boolean checkPopulatedVolumeDataObject(VolumeData book) {
-    return book.getID() != null || book.getTitle() != null || book.getAuthors() != null || book.getDescription() != null
-        || book.getAvgRating() != 0 || book.getCanonicalVolumeLink() != null || book.getThumbnailLink() != null
-        || book.getWebReaderLink() != null;
+    return book.getID() != null && book.getTitle() != null && book.getAuthors() != null && book.getDescription() != null
+        && book.getAvgRating() != 0 && book.getCanonicalVolumeLink() != null && book.getThumbnailLink() != null
+        && book.getWebReaderLink() != null;
   }
 
   @Test
@@ -151,9 +157,9 @@ public class SearchServletTest {
   public void checkConvertResponseToVolumeDataPopulatesObjects() {
     Collection<VolumeData> books = SearchServlet.convertResponseToVolumeData(ARTIFICIAL_JSON_RESPONSE);
 
-    boolean anyNotPopulated = books.stream().anyMatch(book -> checkPopulatedVolumeDataObject(book));
+    boolean allPopulated = books.stream().allMatch(book -> checkPopulatedVolumeDataObject(book));
 
-    Assert.assertTrue(anyNotPopulated);
+    Assert.assertTrue(allPopulated);
   }
 
   @Test


### PR DESCRIPTION
# Description

This PR focuses on adding a case to the SearchServlet when there is a `gbookId` parameter. When there is a `gbookId` parameter, it will retrieve a List of size 1 containing the volume with that id.

This means the two separate cases are
1. gbookId
2. searchTerm and maxResults (optional)

If neither of these are passed, it will return a SC_BAD_REQUEST.

# Breakdown

- Separate doGet to search for 2 cases mentioned above
- Abstract convertResponseToVolumeData into two methods so there is a way to parse the singular book retrieved from the Google Books individual volume call
- Tests
  - Add 3 new tests for the individual response and new error codes
  - Separate artificial JSON response into 3 separate strings to be able to used for the individual book test
  - Minor method to allow for a doGet with improper parameters

# Main Difficulties

Deciding how much of the code in the doGet to keep "global" and what to maintain only in certain if suites. For example, I decided to keep the formatted URL as a "shared" variable since its value was needed and would be modified depending on the value of the parameters.

Returning a list of the VolumeData object(s) no matter whether there is a single VolumeData object or many, I took inspiration from @steven-solar in his abstract get in the Utility class.

# Linked Issue

#63 



