### PR TITLE
Change Assignments and Comments 

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/data/Assignment.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Assignment.java
@@ -3,24 +3,18 @@ package com.google.sps.data;
 import java.util.ArrayList;
 import java.util.List;
 
+
 public class Assignment extends BaseEntity {
   private String text;
   private final String clubID;
-  private List<Comment> comments;
   private final String whenCreated;
   private String whenDue;
 
-  public Assignment(String text, String clubID, List<Comment> comments, String whenCreated,
-      String whenDue) {
+  public Assignment(String text, String clubID, String whenCreated, String whenDue) {
     this.text = text;
     this.clubID = clubID;
-    this.comments = comments;
     this.whenCreated = whenCreated;
     this.whenDue = whenDue;
-  }
-
-  public Assignment(String text, String clubID, String whenCreated, String whenDue) {
-    this(text, clubID, new ArrayList<Comment>(), whenCreated, whenDue);
   }
 
   public Assignment() {
@@ -37,22 +31,6 @@ public class Assignment extends BaseEntity {
 
   public String getClubID() {
     return clubID;
-  }
-
-  public List<Comment> getComments() {
-    return comments;
-  }
-
-  public void setComments(ArrayList<Comment> comments) {
-    this.comments = comments;
-  }
-
-  public void addComment(Comment comment) {
-    this.comments.add(comment);
-  }
-
-  public void removeComment(Comment comment) {
-    this.comments.remove(comment);
   }
 
   public String getWhenCreated() {

--- a/capstone-backend/src/main/java/com/google/sps/data/Club.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Club.java
@@ -5,19 +5,16 @@ import java.util.List;
 
 
 public class Club extends Group {
-  
-  private List<Assignment> assignments;
   private String gbookID;
 
-  public Club(String name, String description, List<Assignment> assignments, 
-      String ownerID, List<String> memberIDs, List<String> inviteIDs, String gbookID) {
+  public Club(String name, String description, String ownerID, List<String> memberIDs, 
+      List<String> inviteIDs, String gbookID) {
     super(name, description, ownerID, memberIDs, inviteIDs);
-    this.assignments = assignments;
     this.gbookID = gbookID;
   }
 
   public Club(String name, String description, String ownerID, String gbookID){
-    this(name, description, new ArrayList<Assignment>(), ownerID, new ArrayList<String>(), new ArrayList<String>(), gbookID);
+    this(name, description, ownerID, new ArrayList<String>(), new ArrayList<String>(), gbookID);
   }
 
   public Club(String name, String ownerID, String gbookID) {
@@ -30,18 +27,6 @@ public class Club extends Group {
 
   public Club() {
     this("", "");
-  }
-
-  public List<Assignment> getAssignments() {
-    return this.assignments;
-  }
-
-  public void addAssignment(Assignment assignment) {
-    this.assignments.add(assignment);
-  }
-
-  public void clearAssignments() {
-    this.assignments.clear();
   }
 
   public String getGbookID() {

--- a/capstone-backend/src/main/java/com/google/sps/data/Comment.java
+++ b/capstone-backend/src/main/java/com/google/sps/data/Comment.java
@@ -2,18 +2,20 @@ package com.google.sps.data;
 
 
 public class Comment extends BaseEntity {
+  private final String assignmentID;
   private final String text;
   private final String userID;
   private final String whenCreated;
 
-  public Comment(String text, String userID, String whenCreated) {
+  public Comment(String assignmentID, String text, String userID, String whenCreated) {
+    this.assignmentID = assignmentID;
     this.text = text;
     this.userID = userID;
     this.whenCreated = whenCreated; 
   }
 
   public Comment() {
-    this("", "", "");
+    this("", "", "", "");
   }
 
   public String getText() {

--- a/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/data/ClubTest.java
@@ -17,9 +17,6 @@ public final class ClubTest {
 
   private static final String DESCRIPTION = "description";
 
-  private static final Assignment ASSIGNMENT_ONE = new Assignment("one", "id", "created", "due");
-  private static final Assignment ASSIGNMENT_TWO = new Assignment("two", "id", "created", "due");
-
   private static final String OWNER = "owner";
   
   private static final String ORIGINAL_BOOK = "originalBook";
@@ -32,37 +29,7 @@ public final class ClubTest {
   
   @Test
   public void testConstructor() {
-    Assert.assertEquals(club.getAssignments().size(), 0);
     Assert.assertEquals(club.getGbookID(), ORIGINAL_BOOK);
-  }
-
-  @Test
-  public void testAssignment() {
-    club.addAssignment(ASSIGNMENT_ONE);
-
-    Assert.assertEquals(club.getAssignments().size(), 1);
-
-    List<Assignment> list = new ArrayList<>(club.getAssignments());
-    Assert.assertEquals(list.get(0), ASSIGNMENT_ONE);
-
-    club.addAssignment(ASSIGNMENT_TWO);
-
-    Assert.assertEquals(club.getAssignments().size(), 2);
-    list = new ArrayList<>(club.getAssignments());
-    Assert.assertEquals(list.get(0), ASSIGNMENT_ONE);
-    Assert.assertEquals(list.get(1), ASSIGNMENT_TWO);
-  }
-
-  @Test
-  public void testClearAssignments() {
-    club.addAssignment(ASSIGNMENT_ONE);
-    club.addAssignment(ASSIGNMENT_TWO);
-
-    Assert.assertEquals(club.getAssignments().size(), 2);
-
-    club.clearAssignments();
-
-    Assert.assertEquals(club.getAssignments().size(), 0);
   }
 
   @Test 


### PR DESCRIPTION
In the last PR, a `Club` stored a list of `Assignments` and an `Assignment` stored a list of `Comments`. We realized now that rather than the "parent" holding a reference to the "child," it should be the other way around. If an assignment held a list of comments, then on comment creation we would need to perform two requests: a post to create the comment, and a put to update the list of comments in the assignment. The same issue arises for a club and its assignments. 

This PR alters this so that an Assignment holds its clubID, and a comment holds its assignmentID. The appropriate testing is updated. 