### PR TITLE
Book Thumbnail Link

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -29,6 +29,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.servlet.annotation.WebServlet;
@@ -212,14 +213,13 @@ public class SearchServlet extends HttpServlet {
     String canonicalVolumeLink = canonVolumeElement != null ? canonVolumeElement.getAsString() : "";
 
     JsonElement thumbnailElement = volumeInfoObj.get("imageLinks");
-    String[] sizes = {"extraLarge", "large", "medium", "small", "thumbnail"};
+    ArrayList<String> sizes = new ArrayList<>(Arrays.asList("extraLarge", "large", "medium", "small", "thumbnail"));
+
     String thumbnailLink = "";
-    for (String size : sizes) {
-      JsonElement retrievedElement = thumbnailElement.getAsJsonObject().get(size);
-      if (retrievedElement != null) {
-        thumbnailLink = retrievedElement.getAsString();
-        break;
-      }
+    String greatestSize = sizes.stream().filter(size -> thumbnailElement.getAsJsonObject().get(size) != null)
+        .findFirst().get();
+    if (greatestSize != null) {
+      thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize).getAsString();
     }
     thumbnailLink = thumbnailLink.replace("http", "https");
 

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -31,6 +31,7 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -216,10 +217,10 @@ public class SearchServlet extends HttpServlet {
     ArrayList<String> sizes = new ArrayList<>(Arrays.asList("extraLarge", "large", "medium", "small", "thumbnail"));
 
     String thumbnailLink = "";
-    String greatestSize = sizes.stream().filter(size -> thumbnailElement.getAsJsonObject().get(size) != null)
-        .findFirst().get();
-    if (greatestSize != null) {
-      thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize).getAsString();
+    Optional<String> greatestSize = sizes.stream().filter(size -> thumbnailElement.getAsJsonObject().get(size) != null)
+        .findFirst();
+    if (greatestSize.isPresent()) {
+      thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize.get().toString()).getAsString();
     }
     thumbnailLink = thumbnailLink.replace("http", "https");
 

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -212,8 +212,15 @@ public class SearchServlet extends HttpServlet {
     String canonicalVolumeLink = canonVolumeElement != null ? canonVolumeElement.getAsString() : "";
 
     JsonElement thumbnailElement = volumeInfoObj.get("imageLinks");
-    String thumbnailLink = thumbnailElement != null ? thumbnailElement.getAsJsonObject().get("thumbnail").getAsString()
-        : "";
+    String[] sizes = {"extraLarge", "large", "medium", "small", "thumbnail"};
+    String thumbnailLink = "";
+    for (String size : sizes) {
+      JsonElement retrievedElement = thumbnailElement.getAsJsonObject().get(size);
+      if (retrievedElement != null) {
+        thumbnailLink = retrievedElement.getAsString();
+        break;
+      }
+    }
     thumbnailLink = thumbnailLink.replace("http", "https");
 
     JsonElement accessInfoElement = bookInfo.get("accessInfo");

--- a/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
@@ -31,8 +31,9 @@ public class SearchServletTest {
   private String jsonResponse;
   private static final String ARTIFICIAL_BOOK_1 = "{\"id\":\"ABCD\",\"volumeInfo\":{\"title\":\""
       + "BookTitle1\",\"authors\":[],\"description\":\"Book 1 description\",\"averageRating\":2,\""
-      + "imageLinks\":{\"thumbnail\":\"Book1Link\"},\"canonicalVolumeLink\":\"canonical volume link 1\""
-      + "},\"accessInfo\":{\"webReaderLink\":\"webreader 1 link\"}}";
+      + "imageLinks\":{\"thumbnail\":\"Book1Link\", \"extraLarge\":\"Book1ExtraLarge\"},"
+      + "\"canonicalVolumeLink\":\"canonical volume link 1\"},\"accessInfo\":{\"webReaderLink\":"
+      + "\"webreader 1 link\"}}";
   private static final String ARTIFICIAL_BOOK_2 = "{\"id\":\"EFGH\",\"volumeInfo\":{\"title\":\""
       + "BookTitle2\",\"authors\":[\"Thomas\",\"Robert\"],\"description\":\"Book 2 description\",\""
       + "averageRating\":4.5,\"imageLinks\":{\"thumbnail\":\"Book2Link\"},\"canonicalVolumeLink\":\""
@@ -180,6 +181,15 @@ public class SearchServletTest {
     VolumeData volume = SearchServlet.individualBookToVolumeData(bookJson);
 
     Assert.assertTrue(checkPopulatedVolumeDataObject(volume));
+  }
+
+  @Test
+  public void checkBookJsonPrioritizesLargestThumbnailSize() {
+    JsonElement bookJson = JsonParser.parseString(ARTIFICIAL_BOOK_1);
+    VolumeData volume = SearchServlet.individualBookToVolumeData(bookJson);
+    String expectedThumbnailLink = "Book1ExtraLarge";
+
+    Assert.assertEquals(expectedThumbnailLink, volume.getThumbnailLink());
   }
 
   @Test


### PR DESCRIPTION
# Description

This PR focuses on the implementation of getting the largest thumbnail link available from the Google Books API call. This order is `extraLarge`, `large`, `medium`, `small`, `thumbnail`. Every book is guaranteed to at least have a `thumbnail` element, but it might not have any sizes of greater quality.

From what I can tell, the books retrieved using the `query` (so, the search for a book using a query parameter) only come with a `thumbnail` element and an equivalent or smaller `smallThumbnail`. Not all books retrieved through individual retrieval have the larger thumbnail sizes, but it is better to display the largest image we can to not show blurry images on the frontend.

# Linked Issue
#72 