### PR TITLE
Book Page Link Integration

### DIFF
--- a/capstone-frontend/src/BookSearchTile.test.js
+++ b/capstone-frontend/src/BookSearchTile.test.js
@@ -30,7 +30,7 @@ test('renders book search tile test', async () => {
   render(<Router><BookSearchTile book={book}
     bookLists={getUserBookLists()} /></Router>, container);
 
-  const bookThumbnail = document.getElementsByClassName('book-img-med')[0];
+  const bookThumbnail = document.getElementsByClassName('book-img-md')[0];
   expect(bookThumbnail).toBeInTheDocument();
 
   const bookTitle = document.getElementsByClassName('book-title')[0];

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
 const popoutDescription = (book) => {
-  let description = book.description;
-  if (description === undefined) {
-    description = "";
-  }
+  let description = book.description || "";
+
   if (description.length > 500) {
     description = description.substring(0, 500).concat('...');
   }
@@ -13,19 +12,18 @@ const popoutDescription = (book) => {
   return (
     <Popover>
       <Popover.Title as='h3'>
-        <a className='center-horizontal'
-          href={`/bookpage/${book.id}`} target='_blank'
-          rel='noopener noreferrer'>
+        <Link to={`/bookpage/${book.id}`} className='center-horizontal'
+          target='_blank' rel='noopener noreferrer'>
           {book.title}
-        </a>
+        </Link>
       </Popover.Title>
-      {description.length > 0 &&
+      {description &&
         <Popover.Content>
           <p className='font-weight-bold'>Description:</p>
           {description}
         </Popover.Content>
       }
-    </Popover >
+    </Popover>
   );
 }
 

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -26,7 +26,7 @@ const popoutDescription = (book) => {
 
 const BookDescriptionOverlay = (props) => {
   return (
-    <OverlayTrigger trigger="hover" placement="right" overlay={popoutDescription(props.book)}>
+    <OverlayTrigger trigger='hover' placement='right' overlay={popoutDescription(props.book)}>
       {props.children}
     </OverlayTrigger>
   );

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -26,7 +26,7 @@ const popoutDescription = (book) => {
 
 const BookDescriptionOverlay = (props) => {
   return (
-    <OverlayTrigger trigger='hover' placement='right' overlay={popoutDescription(props.book)}>
+    <OverlayTrigger trigger='click' placement='right' overlay={popoutDescription(props.book)}>
       {props.children}
     </OverlayTrigger>
   );

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Popover, OverlayTrigger } from 'react-bootstrap';
+
+const popoutDescription = (book) => {
+  let description = book.description;
+  if (description.length > 500) {
+    description = description.substring(0, 500).concat('...');
+  }
+
+  return (
+    <Popover>
+      <Popover.Title as='h3'>
+        <a className='center-horizontal'
+          href={`/bookpage/${book.id}`} target='_blank'
+          rel='noopener noreferrer'>
+          {book.title}
+        </a>
+      </Popover.Title>
+      <Popover.Content>
+        <p className='font-weight-bold'>Description:</p>
+        {description}
+      </Popover.Content>
+    </Popover >
+  );
+}
+
+const BookDescriptionOverlay = (props) => {
+  return (
+    <OverlayTrigger trigger="hover" placement="right" overlay={popoutDescription(props.book)}>
+      {props.children}
+    </OverlayTrigger>
+  );
+}
+
+export { BookDescriptionOverlay };

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -16,17 +16,19 @@ const popoutDescription = (book) => {
           {book.title}
         </a>
       </Popover.Title>
-      <Popover.Content>
-        <p className='font-weight-bold'>Description:</p>
-        {description}
-      </Popover.Content>
+      {description.length > 0 &&
+        <Popover.Content>
+          <p className='font-weight-bold'>Description:</p>
+          {description}
+        </Popover.Content>
+      }
     </Popover >
   );
 }
 
 const BookDescriptionOverlay = (props) => {
   return (
-    <OverlayTrigger trigger='click' placement='right' overlay={popoutDescription(props.book)}>
+    <OverlayTrigger trigger='click' placement='auto' overlay={popoutDescription(props.book)}>
       {props.children}
     </OverlayTrigger>
   );

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
+// Considered making this a stateless functional component used in the Overlay component.
+// When referenced as a component in the overlay prop, the Popover always appears at the
+// top left of the screen even when there is a predefined placement.
 const popoutDescription = (book) => {
   let description = book.description || "";
 

--- a/capstone-frontend/src/components/BookDescriptionOverlay.jsx
+++ b/capstone-frontend/src/components/BookDescriptionOverlay.jsx
@@ -3,6 +3,9 @@ import { Popover, OverlayTrigger } from 'react-bootstrap';
 
 const popoutDescription = (book) => {
   let description = book.description;
+  if (description === undefined) {
+    description = "";
+  }
   if (description.length > 500) {
     description = description.substring(0, 500).concat('...');
   }

--- a/capstone-frontend/src/components/BookPage.jsx
+++ b/capstone-frontend/src/components/BookPage.jsx
@@ -83,6 +83,8 @@ export class BookPage extends Component {
                     </Row>
                     <Row>
                       <h3> Description </h3>
+                    </Row>
+                    <Row>
                       <p className='text-left'> {this.state.book.description} </p>
                     </Row>
                   </Container>

--- a/capstone-frontend/src/components/BookSearchTile.jsx
+++ b/capstone-frontend/src/components/BookSearchTile.jsx
@@ -5,23 +5,23 @@ import '../styles/Book.css';
 
 const BookSearchTile = (props) => {
   return (
-    <div className="book-search-tile">
+    <div className='book-search-tile'>
       <Container>
-        <Row className="justify-content-md-center">
-          <Col md="auto">
+        <Row className='justify-content-md-center'>
+          <Col md='auto'>
             <a className='text-decoration-none text-body'
               href={`/bookpage/${props.book.id}`}>
-              <img className="book-img-med" src={props.book.thumbnailLink} alt={props.book.title} />
+              <img className='book-img-med' src={props.book.thumbnailLink} alt={props.book.title} />
             </a>
           </Col>
           <Col>
-            <div className="center-vertical">
-              <h2 className="book-title"> {props.book.title} </h2>
-              <p className="book-authors"> {props.book.authors.join(', ')} </p>
+            <div className='center-vertical'>
+              <h2 className='book-title'> {props.book.title} </h2>
+              <p className='book-authors'> {props.book.authors.join(', ')} </p>
             </div>
           </Col>
-          <Col md="auto">
-            <Container className="center-vertical">
+          <Col md='auto'>
+            <Container className='center-vertical'>
               <BookListAddDropdown bookLists={props.bookLists} updateBookLists={props.updateBookLists} book={props.book} />
             </Container>
           </Col>

--- a/capstone-frontend/src/components/BookSearchTile.jsx
+++ b/capstone-frontend/src/components/BookSearchTile.jsx
@@ -11,7 +11,7 @@ const BookSearchTile = (props) => {
           <Col md='auto'>
             <a className='text-decoration-none text-body'
               href={`/bookpage/${props.book.id}`}>
-              <img className='book-img-med' src={props.book.thumbnailLink} alt={props.book.title} />
+              <img className='book-img-md' src={props.book.thumbnailLink} alt={props.book.title} />
             </a>
           </Col>
           <Col>

--- a/capstone-frontend/src/components/BookSearchTile.jsx
+++ b/capstone-frontend/src/components/BookSearchTile.jsx
@@ -9,7 +9,10 @@ const BookSearchTile = (props) => {
       <Container>
         <Row className="justify-content-md-center">
           <Col md="auto">
-            <img className="book-img-med" src={props.book.thumbnailLink} alt={props.book.title} />
+            <a className='text-decoration-none text-body'
+              href={`/bookpage/${props.book.id}`}>
+              <img className="book-img-med" src={props.book.thumbnailLink} alt={props.book.title} />
+            </a>
           </Col>
           <Col>
             <div className="center-vertical">

--- a/capstone-frontend/src/components/BookSearchTile.jsx
+++ b/capstone-frontend/src/components/BookSearchTile.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { BookListAddDropdown } from './BookListAddDropdown';
+import { BookDescriptionOverlay } from './BookDescriptionOverlay';
 import '../styles/Book.css';
 
 const BookSearchTile = (props) => {
@@ -9,10 +10,9 @@ const BookSearchTile = (props) => {
       <Container>
         <Row className='justify-content-md-center'>
           <Col md='auto'>
-            <a className='text-decoration-none text-body'
-              href={`/bookpage/${props.book.id}`}>
+            <BookDescriptionOverlay book={props.book}>
               <img className='book-img-md' src={props.book.thumbnailLink} alt={props.book.title} />
-            </a>
+            </BookDescriptionOverlay>
           </Col>
           <Col>
             <div className='center-vertical'>

--- a/capstone-frontend/src/components/CreateList.jsx
+++ b/capstone-frontend/src/components/CreateList.jsx
@@ -122,7 +122,7 @@ class CreateList extends Component {
 
     return (
       <Popover>
-        <Popover.Title as="h3">
+        <Popover.Title as='h3'>
           <a className='center-horizontal'
             href={`/bookpage/${book.id}`} target='_blank'
             rel='noopener noreferrer'>
@@ -130,7 +130,7 @@ class CreateList extends Component {
           </a>
         </Popover.Title>
         <Popover.Content>
-          <p className="font-weight-bold">Description:</p>
+          <p className='font-weight-bold'>Description:</p>
           {description}
         </Popover.Content>
       </Popover >

--- a/capstone-frontend/src/components/CreateList.jsx
+++ b/capstone-frontend/src/components/CreateList.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import { withRouter } from 'react-router-dom'
-import { Button, Form, Spinner, Modal, Col, Row, Popover, OverlayTrigger } from 'react-bootstrap'
+import { withRouter } from 'react-router-dom';
+import { Button, Form, Spinner, Modal, Col, Row } from 'react-bootstrap';
+import { BookDescriptionOverlay } from './BookDescriptionOverlay';
 
 class CreateList extends Component {
 
@@ -113,29 +114,6 @@ class CreateList extends Component {
     this.props.updateBookLists();
   }
 
-  popoutDescription = (book) => {
-    let description = book.description;
-    if (description.length > 500) {
-      description = description.substring(0, 500).concat('...');
-    }
-
-    return (
-      <Popover>
-        <Popover.Title as='h3'>
-          <a className='center-horizontal'
-            href={`/bookpage/${book.id}`} target='_blank'
-            rel='noopener noreferrer'>
-            {book.title}
-          </a>
-        </Popover.Title>
-        <Popover.Content>
-          <p className='font-weight-bold'>Description:</p>
-          {description}
-        </Popover.Content>
-      </Popover >
-    );
-  }
-
   render() {
     return (
       <>
@@ -186,9 +164,9 @@ class CreateList extends Component {
                   <Row className="px-3 text-center">
                     {this.state.searchResults.map(book =>
                       <Col md={3} className="px-2 my-0 border" key={book.id}>
-                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(book)}>
+                        <BookDescriptionOverlay book={book}>
                           <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
-                        </OverlayTrigger>
+                        </BookDescriptionOverlay>
                         <h5 className="mt-4"> {book.title} </h5>
                         <p className="my-1"> {book.authors.join(', ')} </p>
                         {this.state.addedBooksIDs.includes(book.id) ?
@@ -210,9 +188,9 @@ class CreateList extends Component {
                     {this.state.addedBooks.map(addedBook =>
 
                       <Col md={3} className="px-2 my-0 border" key={addedBook.id}>
-                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(addedBook)}>
+                        <BookDescriptionOverlay book={addedBook}>
                           <img className="img-responsive mt-3 p-0 rounded book-img-sm" src={addedBook.thumbnailLink} alt={addedBook.title} />
-                        </OverlayTrigger>
+                        </BookDescriptionOverlay>
                         <h5 className="mt-4"> {addedBook.title} </h5>
                         <p className="my-1"> {addedBook.authors.join(', ')} </p>
                         <Button className="my-5" variant="danger" onClick={() => this.removeBookFromList(addedBook)}>Remove Book</Button>

--- a/capstone-frontend/src/components/CreateList.jsx
+++ b/capstone-frontend/src/components/CreateList.jsx
@@ -114,10 +114,16 @@ class CreateList extends Component {
   }
 
   popoutDescription = (book) => {
+    // Check for greater than 500 chars, if so then substring with ...
+    let description = book.description;
+    if (description.length > 500) {
+      description = description.substring(0, 500).concat('...');
+    }
+
     return (
       <Popover>
         <Popover.Title as="h3">
-          <a className='text-decoration-none text-body center-horizontal'
+          <a className='center-horizontal'
             href={`/bookpage/${book.id}`} target='_blank'
             rel='noopener noreferrer'>
             {book.title}
@@ -125,15 +131,15 @@ class CreateList extends Component {
         </Popover.Title>
         <Popover.Content>
           <p className="font-weight-bold">Description:</p>
-          {book.description}
+          {description}
         </Popover.Content>
-      </Popover>
+      </Popover >
     );
   }
 
   render() {
     return (
-      <div>
+      <>
         <button className={this.props.btnStyle} onClick={() => this.setState({ showModal: true })}>
           <div className={this.props.textStyle}>
             <span id="create-list-modal"> Create New List </span>
@@ -234,7 +240,7 @@ class CreateList extends Component {
             </Form>
           </Modal.Body>
         </Modal>
-      </div>
+      </>
     )
   }
 }

--- a/capstone-frontend/src/components/CreateList.jsx
+++ b/capstone-frontend/src/components/CreateList.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom'
-import { Button, Form, Spinner, Modal, Col, Row } from 'react-bootstrap'
+import { Button, Form, Spinner, Modal, Col, Row, Popover, OverlayTrigger } from 'react-bootstrap'
 
 class CreateList extends Component {
 
@@ -28,7 +28,7 @@ class CreateList extends Component {
 
     if (searchTerm === "") {
       searchResults = [];
-      
+
       this.setState({ searchResults, displayBooks: false, fetchingBooks: false })
     }
     else {
@@ -113,6 +113,24 @@ class CreateList extends Component {
     this.props.updateBookLists();
   }
 
+  popoutDescription = (book) => {
+    return (
+      <Popover>
+        <Popover.Title as="h3">
+          <a className='text-decoration-none text-body center-horizontal'
+            href={`/bookpage/${book.id}`} target='_blank'
+            rel='noopener noreferrer'>
+            {book.title}
+          </a>
+        </Popover.Title>
+        <Popover.Content>
+          <p className="font-weight-bold">Description:</p>
+          {book.description}
+        </Popover.Content>
+      </Popover>
+    );
+  }
+
   render() {
     return (
       <div>
@@ -163,7 +181,9 @@ class CreateList extends Component {
                   <Row className="px-3 text-center">
                     {this.state.searchResults.map(book =>
                       <Col md={3} className="px-2 my-0 border" key={book.id}>
-                        <img className="img-responsive mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
+                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(book)}>
+                          <img className="img-responsive mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
+                        </OverlayTrigger>
                         <h5 className="mt-4"> {book.title} </h5>
                         <p className="my-1"> {book.authors.join(', ')} </p>
                         {this.state.addedBooksIDs.includes(book.id) ?
@@ -185,7 +205,9 @@ class CreateList extends Component {
                     {this.state.addedBooks.map(addedBook =>
 
                       <Col md={3} className="px-2 my-0 border" key={addedBook.id}>
-                        <img className="img-responsive mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
+                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(addedBook)}>
+                          <img className="img-responsive mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
+                        </OverlayTrigger>
                         <h5 className="mt-4"> {addedBook.title} </h5>
                         <p className="my-1"> {addedBook.authors.join(', ')} </p>
                         <Button className="my-5" variant="danger" onClick={() => this.removeBookFromList(addedBook)}>Remove Book</Button>

--- a/capstone-frontend/src/components/CreateList.jsx
+++ b/capstone-frontend/src/components/CreateList.jsx
@@ -114,7 +114,6 @@ class CreateList extends Component {
   }
 
   popoutDescription = (book) => {
-    // Check for greater than 500 chars, if so then substring with ...
     let description = book.description;
     if (description.length > 500) {
       description = description.substring(0, 500).concat('...');
@@ -188,7 +187,7 @@ class CreateList extends Component {
                     {this.state.searchResults.map(book =>
                       <Col md={3} className="px-2 my-0 border" key={book.id}>
                         <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(book)}>
-                          <img className="img-responsive mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
+                          <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
                         </OverlayTrigger>
                         <h5 className="mt-4"> {book.title} </h5>
                         <p className="my-1"> {book.authors.join(', ')} </p>
@@ -212,7 +211,7 @@ class CreateList extends Component {
 
                       <Col md={3} className="px-2 my-0 border" key={addedBook.id}>
                         <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(addedBook)}>
-                          <img className="img-responsive mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
+                          <img className="img-responsive mt-3 p-0 rounded book-img-sm" src={addedBook.thumbnailLink} alt={addedBook.title} />
                         </OverlayTrigger>
                         <h5 className="mt-4"> {addedBook.title} </h5>
                         <p className="my-1"> {addedBook.authors.join(', ')} </p>

--- a/capstone-frontend/src/components/ListPage.jsx
+++ b/capstone-frontend/src/components/ListPage.jsx
@@ -99,7 +99,7 @@ class ListPage extends Component {
                   <Row className="text-center border m-5 bg-light light-gray-border" key={gBook.id + this.props.match.params.id} >
                     <Col md={3} className="my-4 p-0 ">
                       <a className="text-decoration-none text-body" href={`/bookpage/${gBook.id}`}>
-                        <img className="img-responsive" src={gBook.thumbnailLink} alt={gBook.title} />
+                        <img className="img-fluid book-img-md" src={gBook.thumbnailLink} alt={gBook.title} />
                       </a>
                     </Col>
 

--- a/capstone-frontend/src/components/ListPage.jsx
+++ b/capstone-frontend/src/components/ListPage.jsx
@@ -98,8 +98,7 @@ class ListPage extends Component {
                 this.state.gBooks.map(gBook =>
                   <Row className="text-center border m-5 bg-light light-gray-border" key={gBook.id + this.props.match.params.id} >
                     <Col md={3} className="my-4 p-0 ">
-                      {/* TODO(#79): Redirect user to BookPage instead of playstore */}
-                      <a className="text-decoration-none text-body" href={gBook.canonicalVolumeLink}>
+                      <a className="text-decoration-none text-body" href={`/bookpage/${gBook.id}`}>
                         <img className="img-responsive" src={gBook.thumbnailLink} alt={gBook.title} />
                       </a>
                     </Col>
@@ -111,7 +110,7 @@ class ListPage extends Component {
                         starDimension="40px"
                         starSpacing="10px"
                         starRatedColor="gold" />
-                        <p className="my-3" > {gBook.authors.join(', ')} </p>
+                      <p className="my-3" > {gBook.authors.join(', ')} </p>
                     </Col>
 
                     <Col md={3} className="my-4 p-0">

--- a/capstone-frontend/src/components/ListPage.jsx
+++ b/capstone-frontend/src/components/ListPage.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Button, Spinner, Row, Col } from 'react-bootstrap'
 import StarRatings from 'react-star-ratings'
 import { SearchBookModal } from './SearchBookModal'
+import { BookDescriptionOverlay } from './BookDescriptionOverlay';
 import '../styles/ListPage.css'
 
 class ListPage extends Component {
@@ -147,11 +148,10 @@ class ListPage extends Component {
                 this.state.gBooks.map(gBook =>
                   <Row className="text-center border m-5 bg-light light-gray-border" key={gBook.id + this.props.match.params.id} >
                     <Col md={3} className="my-4 p-0 ">
-                      <a className="text-decoration-none text-body" href={`/bookpage/${gBook.id}`}>
+                      <BookDescriptionOverlay book={gBook}>
                         <img className="img-fluid book-img-md" src={gBook.thumbnailLink} alt={gBook.title} />
-                      </a>
+                      </BookDescriptionOverlay>
                     </Col>
-
                     <Col className="my-4 p-0">
                       <h2 className="mt-4"> {gBook.title} </h2>
                       <StarRatings

--- a/capstone-frontend/src/components/SearchBookModal.jsx
+++ b/capstone-frontend/src/components/SearchBookModal.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Button, Form, Spinner, Modal, Col, Row, Popover, OverlayTrigger } from 'react-bootstrap'
+import { Button, Form, Spinner, Modal, Col, Row } from 'react-bootstrap'
+import { BookDescriptionOverlay } from './BookDescriptionOverlay';
 
 export class SearchBookModal extends Component {
 
@@ -128,29 +129,6 @@ export class SearchBookModal extends Component {
     }
   }
 
-  popoutDescription = (book) => {
-    let description = book.description;
-    if (description.length > 500) {
-      description = description.substring(0, 500).concat('...');
-    }
-
-    return (
-      <Popover>
-        <Popover.Title as='h3'>
-          <a className='center-horizontal'
-            href={`/bookpage/${book.id}`} target='_blank'
-            rel='noopener noreferrer'>
-            {book.title}
-          </a>
-        </Popover.Title>
-        <Popover.Content>
-          <p className='font-weight-bold'>Description:</p>
-          {description}
-        </Popover.Content>
-      </Popover >
-    );
-  }
-
   render() {
     return (
       <div>
@@ -196,9 +174,9 @@ export class SearchBookModal extends Component {
                   <Row className="px-3 text-center">
                     {this.state.searchResults.map(book =>
                       <Col md={3} className="px-2 my-0 border" key={book.id}>
-                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(book)}>
+                        <BookDescriptionOverlay book={book}>
                           <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
-                        </OverlayTrigger>
+                        </BookDescriptionOverlay>
                         <h5 className="mt-4"> {book.title} </h5>
                         <p className="my-1"> {book.authors.join(', ')} </p>
                         {this.state.addedBooksIDs.includes(book.id) ?
@@ -221,9 +199,9 @@ export class SearchBookModal extends Component {
                       <Row className="text-center px-3">
                         {
                           <Col className="px-2 my-0 border" key={this.state.addedBooks[0].id}>
-                            <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(this.state.addedBooks[0])}>
+                            <BookDescriptionOverlay book={this.state.addedBooks[0]}>
                               <img className="img-fluid book-img-sm mt-4 p-0 rounded" src={this.state.addedBooks[0].thumbnailLink} alt={this.state.addedBooks[0].title} />
-                            </OverlayTrigger>
+                            </BookDescriptionOverlay>
                             <h5 className="my-4"> {this.state.addedBooks[0].title} </h5>
                             <p className="my-1"> {this.state.addedBooks[0].authors.join(', ')} </p>
                             <Button className="my-4" variant="danger" onClick={() => this.removeBookFromList(this.state.addedBooks[0])}>Remove Book</Button>
@@ -237,9 +215,9 @@ export class SearchBookModal extends Component {
                       <Row className="text-center px-3">
                         {this.state.addedBooks.map(addedBook =>
                           <Col md={3} className="px-2 my-0 border" key={addedBook.id}>
-                            <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(addedBook)}>
+                            <BookDescriptionOverlay book={this.state.addedBook}>
                               <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
-                            </OverlayTrigger>
+                            </BookDescriptionOverlay>
                             <h5 className="mt-4"> {addedBook.title} </h5>
                             <p className="my-1"> {addedBook.authors.join(', ')} </p>
                             <Button className="my-5" variant="danger" onClick={() => this.removeBookFromList(addedBook)}>Remove Book</Button>

--- a/capstone-frontend/src/components/SearchBookModal.jsx
+++ b/capstone-frontend/src/components/SearchBookModal.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Form, Spinner, Modal, Col, Row } from 'react-bootstrap'
+import { Button, Form, Spinner, Modal, Col, Row, Popover, OverlayTrigger } from 'react-bootstrap'
 
 export class SearchBookModal extends Component {
 
@@ -128,6 +128,29 @@ export class SearchBookModal extends Component {
     }
   }
 
+  popoutDescription = (book) => {
+    let description = book.description;
+    if (description.length > 500) {
+      description = description.substring(0, 500).concat('...');
+    }
+
+    return (
+      <Popover>
+        <Popover.Title as='h3'>
+          <a className='center-horizontal'
+            href={`/bookpage/${book.id}`} target='_blank'
+            rel='noopener noreferrer'>
+            {book.title}
+          </a>
+        </Popover.Title>
+        <Popover.Content>
+          <p className='font-weight-bold'>Description:</p>
+          {description}
+        </Popover.Content>
+      </Popover >
+    );
+  }
+
   render() {
     return (
       <div>
@@ -173,7 +196,9 @@ export class SearchBookModal extends Component {
                   <Row className="px-3 text-center">
                     {this.state.searchResults.map(book =>
                       <Col md={3} className="px-2 my-0 border" key={book.id}>
-                        <img className="img-responsive mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
+                        <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(book)}>
+                          <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={book.thumbnailLink} alt={book.title} />
+                        </OverlayTrigger>
                         <h5 className="mt-4"> {book.title} </h5>
                         <p className="my-1"> {book.authors.join(', ')} </p>
                         {this.state.addedBooksIDs.includes(book.id) ?
@@ -196,7 +221,9 @@ export class SearchBookModal extends Component {
                       <Row className="text-center px-3">
                         {
                           <Col className="px-2 my-0 border" key={this.state.addedBooks[0].id}>
-                            <img className="img-responsive mt-4 p-0 rounded" src={this.state.addedBooks[0].thumbnailLink} alt={this.state.addedBooks[0].title} />
+                            <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(this.state.addedBooks[0])}>
+                              <img className="img-fluid book-img-sm mt-4 p-0 rounded" src={this.state.addedBooks[0].thumbnailLink} alt={this.state.addedBooks[0].title} />
+                            </OverlayTrigger>
                             <h5 className="my-4"> {this.state.addedBooks[0].title} </h5>
                             <p className="my-1"> {this.state.addedBooks[0].authors.join(', ')} </p>
                             <Button className="my-4" variant="danger" onClick={() => this.removeBookFromList(this.state.addedBooks[0])}>Remove Book</Button>
@@ -209,9 +236,10 @@ export class SearchBookModal extends Component {
                       <h2 className="text-center my-4 px-4 ">Added Books</h2>
                       <Row className="text-center px-3">
                         {this.state.addedBooks.map(addedBook =>
-
                           <Col md={3} className="px-2 my-0 border" key={addedBook.id}>
-                            <img className="img-responsive mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
+                            <OverlayTrigger trigger="click" placement="right" overlay={this.popoutDescription(addedBook)}>
+                              <img className="img-fluid book-img-sm mt-3 p-0 rounded" src={addedBook.thumbnailLink} alt={addedBook.title} />
+                            </OverlayTrigger>
                             <h5 className="mt-4"> {addedBook.title} </h5>
                             <p className="my-1"> {addedBook.authors.join(', ')} </p>
                             <Button className="my-5" variant="danger" onClick={() => this.removeBookFromList(addedBook)}>Remove Book</Button>

--- a/capstone-frontend/src/styles/Book.css
+++ b/capstone-frontend/src/styles/Book.css
@@ -1,11 +1,16 @@
+.book-img-sm {
+  height: auto;
+  width: 128px;
+}
+
 .book-img-md {
   height: auto;
-  width:128px;
+  width: 164px;
 }
 
 .book-img-lg {
   height: auto;
-  width:256px;
+  width: 256px;
 }
 
 .book-search-tile {

--- a/capstone-frontend/src/styles/Book.css
+++ b/capstone-frontend/src/styles/Book.css
@@ -1,3 +1,8 @@
+.book-img-md {
+  height: auto;
+  width:128px;
+}
+
 .book-img-lg {
   height: auto;
   width:256px;


### PR DESCRIPTION
# Description

This PR focuses on the integration of the BookPage link in the other pages of the application: `BookSearchTile`, `CreateList`, `ListPage` and `SearchBookModal`. 

It creates the BookDescriptionOverlay, a component used to wrap around the book image and give a description popup when the user clicks on the image.

Finishes work started in #76 

# Breakdown
- Create BookDescriptionOverlay using react bootstrap popovers
  - Renders all children inside of it
  - If there is a description over 500 chars, cut off and add ellipsis
  - If there is an empty description, do not show the description tag
- Add BookDescriptionOverlay to `BookSearchTile`, `CreateList`, `ListPage` and `SearchBookModal`
- Add image classes in the CSS to ensure the sizes are as expected and not too large
- Minor string literal changes

# Main Difficulties

Deciding whether to implement this as a function in each necessary class or make a new component for it.

Placing the Overlay simply on the modals, SearchBookModal and CreateList, or all pages referencing books.

# Screenshot of Feature

This is the description overlay shown when clicking on a book image.

![Populated Description Overlay](https://user-images.githubusercontent.com/20411913/88201875-abf7b400-cc0d-11ea-9db0-3e44b3791aab.png)

This is the description overlay shown when clicking on a book image with no description.

![Empty Description Overlay](https://user-images.githubusercontent.com/20411913/88201924-b914a300-cc0d-11ea-8ec5-58266811da4a.png)


# Linked Issue
#79

