### PR TITLE
Fix rerendering of Browse page on Search Nav update

### DIFF
--- a/capstone-frontend/src/components/BookSearchList.jsx
+++ b/capstone-frontend/src/components/BookSearchList.jsx
@@ -22,6 +22,12 @@ class BookSearchList extends Component {
     this.getData();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.searchQuery !== prevProps.searchQuery) {
+      this.getData();
+    }
+  }
+
   render() {
     return (
       <div>


### PR DESCRIPTION
# Description
After using the Search in the navbar again after an initial search, the page does not rerender without a full refresh of the page. 

In this PR, I have added a `componentDidUpdate` method to ensure that the page refreshes when the searchQuery prop changes (the prop that gets pulled down from App.jsx).

# Linked Issue
#98 

Thanks to @steven-solar for pointing this out!