### PR TITLE
Fix mobile ClubGridItems and UserCards

### DIFF
--- a/capstone-frontend/src/components/ClubGridItem.jsx
+++ b/capstone-frontend/src/components/ClubGridItem.jsx
@@ -46,7 +46,7 @@ class ClubGridItem extends Component {
     const isRequester = this.props.club.requestIDs.includes(userID);
     return (
       <Col xs={12} sm={6} md={3}>
-        <Card className="col-3 group-container">
+        <Card className="group-container">
           <Link id="group-link" to={`/clubpage/${this.props.club.id}`}>
             {isOwner && <Card.Header className="header text-muted"> Owner </Card.Header>}
             {isMember && <Card.Header className="header text-muted"> Member </Card.Header>}

--- a/capstone-frontend/src/components/ClubGridItem.jsx
+++ b/capstone-frontend/src/components/ClubGridItem.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Card } from 'react-bootstrap';
+import { Button, Card, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
 import '../styles/Groups.css';
@@ -11,18 +11,18 @@ class ClubGridItem extends Component {
       requested: this.props.club.requestIDs.includes(window.localStorage.getItem("userID"))
     }
   }
-  
+
   requestJoin = () => {
     const putBody = {
       id: this.props.club.id,
       add_requestIDs: window.localStorage.getItem("userID")
     };
-    fetch(`/api/clubs`, {method: "put", body: JSON.stringify(putBody)})
-        .then(this.setState({requested: true}))
-        .catch(function(err) {
-          //TODO #61: Centralize error output
-          alert(err);
-        });
+    fetch(`/api/clubs`, { method: "put", body: JSON.stringify(putBody) })
+      .then(this.setState({ requested: true }))
+      .catch(function (err) {
+        //TODO #61: Centralize error output
+        alert(err);
+      });
   }
 
   unRequestJoin = () => {
@@ -30,9 +30,9 @@ class ClubGridItem extends Component {
       "id": this.props.club.id,
       "remove_requestIDs": window.localStorage.getItem("userID")
     };
-    fetch(`/api/clubs`, {method: "put", body: JSON.stringify(putBody)})
-        .then(this.setState({requested: false}))
-        .catch(function(err) {
+    fetch(`/api/clubs`, { method: "put", body: JSON.stringify(putBody)})
+        .then(this.setState({ requested: false }))
+        .catch(function (err) {
           //TODO #61: Centralize error output
           alert(err);
         });
@@ -45,21 +45,23 @@ class ClubGridItem extends Component {
     const isViewer = !isOwner && !isMember;
     const isRequester = this.props.club.requestIDs.includes(userID);
     return (
-      <Card className="col-3 group-container">
-        <Link id="group-link" to={`/clubpage/${this.props.club.id}`}>
-          {isOwner && <Card.Header className="header text-muted"> Owner </Card.Header>}
-          {isMember && <Card.Header className="header text-muted"> Member </Card.Header>}
-          {isViewer && <Card.Header className="header text-muted"> Viewer </Card.Header>}
-          <Card.Body>
-            <Card.Title id="group-name"> {this.props.club.name} </Card.Title>
-            <Card.Subtitle className="mb-2 text-muted" id="group-gbook"> Reading: {this.props.club.bookTitle} </Card.Subtitle>
-            <Card.Text id="group-description"> {this.props.club.description} </Card.Text>
-            {isViewer && !isRequester && <Button variant="primary" onClick={this.requestJoin}> Request to Join! </Button>}
-            {isRequester && <Button variant="danger" onClick={this.unRequestJoin}> Withdraw Request </Button>}
-          </Card.Body>
-          <Card.Footer className="footer text-muted"> {this.props.club.memberIDs.length} Members </Card.Footer>
-        </Link>
-      </Card>
+      <Col xs={12} sm={6} md={3}>
+        <Card className="col-3 group-container">
+          <Link id="group-link" to={`/clubpage/${this.props.club.id}`}>
+            {isOwner && <Card.Header className="header text-muted"> Owner </Card.Header>}
+            {isMember && <Card.Header className="header text-muted"> Member </Card.Header>}
+            {isViewer && <Card.Header className="header text-muted"> Viewer </Card.Header>}
+            <Card.Body>
+              <Card.Title id="group-name"> {this.props.club.name} </Card.Title>
+              <Card.Subtitle className="mb-2 text-muted" id="group-gbook"> Reading: {this.props.club.bookTitle} </Card.Subtitle>
+              <Card.Text id="group-description"> {this.props.club.description} </Card.Text>
+              {isViewer && !isRequester && <Button variant="primary" onClick={this.requestJoin}> Request to Join! </Button>}
+              {isRequester && <Button variant="danger" onClick={this.unRequestJoin}> Withdraw Request </Button>}
+            </Card.Body>
+            <Card.Footer className="footer text-muted"> {this.props.club.memberIDs.length} Members </Card.Footer>
+          </Link>
+        </Card>
+      </Col>
     );
   }
 

--- a/capstone-frontend/src/components/UserCard.jsx
+++ b/capstone-frontend/src/components/UserCard.jsx
@@ -101,7 +101,7 @@ export class UserCard extends Component {
         </Button>
       </div>
     return (
-      <Col className='user-card' xs={{ span: '2' }} >
+      <Col className='user-card' xs={12} sm={6} md={2} >
         <img id='user-profile' src={this.props.user.profileImageUrl} alt='Profile' />
         <div> {this.props.user.fullName} </div>
         {this.state.isFriend 


### PR DESCRIPTION
ClubGridItems and UserCards were given the same 3 and 2 columns, respectively on all screen sizes. On mobile devices with smaller screens, they appeared to be "smushed" and hard to read/interact with:

![image](https://user-images.githubusercontent.com/43327083/88664612-51e26d00-d0ab-11ea-9bfd-14902a1aa4b2.png)
![Screenshot 2020-07-28 at 8 17 06 AM](https://user-images.githubusercontent.com/43327083/88664468-1d6eb100-d0ab-11ea-835b-8c29fbb0a00a.png)

This PR fixes these issues by giving them varying column sizes for xs, sm and md screens. For example, here are the new ClubGridItems. The UserCards were changed similarly. 

![Screenshot 2020-07-28 at 12 13 45 AM](https://user-images.githubusercontent.com/43327083/88664561-3bd4ac80-d0ab-11ea-9207-7bde98548a73.png)

