### PR TITLE
Search Servlet - Thumbnail Fix

### DIFF
--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -225,7 +225,7 @@ public class SearchServlet extends HttpServlet {
       if (greatestSize.isPresent()) {
         thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize.get().toString()).getAsString();
       }
-      thumbnailLink = thumbnailLink.replace("http", "https");
+      thumbnailLink = thumbnailLink.replace("http:", "https:");
     }
 
     JsonElement accessInfoElement = bookInfo.get("accessInfo");

--- a/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/capstone-backend/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -43,6 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 public class SearchServlet extends HttpServlet {
 
   public final static int DEFAULT_MAX_RESULTS = 5;
+  public final static String DEFAULT_THUMBNAIL_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/4/48/Gray_book_question.png";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -136,7 +137,8 @@ public class SearchServlet extends HttpServlet {
       }
     }
 
-    Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+    response.setCharacterEncoding("UTF8");
     response.getWriter().println(gson.toJson(volumes));
   }
 
@@ -216,13 +218,15 @@ public class SearchServlet extends HttpServlet {
     JsonElement thumbnailElement = volumeInfoObj.get("imageLinks");
     ArrayList<String> sizes = new ArrayList<>(Arrays.asList("extraLarge", "large", "medium", "small", "thumbnail"));
 
-    String thumbnailLink = "";
-    Optional<String> greatestSize = sizes.stream().filter(size -> thumbnailElement.getAsJsonObject().get(size) != null)
-        .findFirst();
-    if (greatestSize.isPresent()) {
-      thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize.get().toString()).getAsString();
+    String thumbnailLink = DEFAULT_THUMBNAIL_IMAGE;
+    if (thumbnailElement != null) {
+      Optional<String> greatestSize = sizes.stream()
+          .filter(size -> thumbnailElement.getAsJsonObject().get(size) != null).findFirst();
+      if (greatestSize.isPresent()) {
+        thumbnailLink = thumbnailElement.getAsJsonObject().get(greatestSize.get().toString()).getAsString();
+      }
+      thumbnailLink = thumbnailLink.replace("http", "https");
     }
-    thumbnailLink = thumbnailLink.replace("http", "https");
 
     JsonElement accessInfoElement = bookInfo.get("accessInfo");
     String webReaderLink = accessInfoElement != null

--- a/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
@@ -110,19 +110,6 @@ public class SearchServletTest {
   }
 
   @Test
-  public void ensureJsonResponseIsInCorrectFormat() {
-    // Response should be an array of JSON objects, in the form of:
-    // [{book1Info}, {book2Info}...]
-    // Remove all whitespace as we only care about the beginning and ending characters
-    jsonResponse = jsonResponse.replaceAll("\\s","");
-    Assert.assertEquals(jsonResponse.charAt(0), '[');
-    Assert.assertEquals(jsonResponse.charAt(jsonResponse.length() - 1), ']');
-
-    Assert.assertEquals(jsonResponse.charAt(1), '{');
-    Assert.assertEquals(jsonResponse.charAt(jsonResponse.length() - 2), '}');
-  }
-
-  @Test
   public void ensureDefaultNumberOfBooksInResponse() {
     // Response should contain the number of default results, since there was no
     // parameter included

--- a/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
+++ b/capstone-backend/src/test/java/com/google/sps/servlets/SearchServletTest.java
@@ -113,7 +113,8 @@ public class SearchServletTest {
   public void ensureJsonResponseIsInCorrectFormat() {
     // Response should be an array of JSON objects, in the form of:
     // [{book1Info}, {book2Info}...]
-
+    // Remove all whitespace as we only care about the beginning and ending characters
+    jsonResponse = jsonResponse.replaceAll("\\s","");
     Assert.assertEquals(jsonResponse.charAt(0), '[');
     Assert.assertEquals(jsonResponse.charAt(jsonResponse.length() - 1), ']');
 

--- a/capstone-frontend/src/components/BookPage.jsx
+++ b/capstone-frontend/src/components/BookPage.jsx
@@ -79,7 +79,7 @@ export class BookPage extends Component {
                         starSpacing='10px'
                         starRatedColor='gold'
                       />
-                      {book.avgRating === 0 && <p id='rating-label'>No Ratings</p>}
+                      {book.avgRating === -1 && <p id='rating-label'>No Ratings</p>}
                     </Row>
                     <Row>
                       <h3> Description </h3>

--- a/capstone-frontend/src/components/BookPage.jsx
+++ b/capstone-frontend/src/components/BookPage.jsx
@@ -79,7 +79,7 @@ export class BookPage extends Component {
                         starSpacing='10px'
                         starRatedColor='gold'
                       />
-                      {book.avgRating === -1 && <p id='rating-label'>No Ratings</p>}
+                      {book.avgRating < 1 && <p id='rating-label'>No Ratings</p>}
                     </Row>
                     <Row>
                       <h3> Description </h3>


### PR DESCRIPTION
# Description
Through more testing on our app, I realized that not all books retrieved from the Google Books API are guaranteed to have thumbnails (stored in the imageLinks object). When a search query ran into one of these books, it would crash, and nothing would appear on the frontend.

To avoid this, I added a check to see if the imageLinks object is null. If it is null, then a link to an image depicting a book with a question mark on it will be returned to the frontend. This ensures there is a consistent user experience on the frontend, where they can continue to click on the image and be directed to the book's specific bookpage via the book overlay.

Note: I also added a small fix to the frontend that shows "no rating" when there are no ratings on the book. This was not showing up appropriately before.

# Screenshot of Feature

This is one of the books that lacks a thumbnail, so its image link was replaced with this alternate image.
![Unknown Question Mark Book](https://user-images.githubusercontent.com/20411913/88706148-11e4af80-d0d6-11ea-883a-f070bffa762e.png)

# Linked Issue
Finished #72 