### PR TITLE
Add Guava Dependency to fix backend breaking

### DIFF
--- a/capstone-backend/pom.xml
+++ b/capstone-backend/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
The backend was not functioning properly due to the absence of the guava dependency in the `pom.xml` file. This PR re-adds this dependency and fixes the backend, unblocking progress on other branches. 