### PR TITLE
Handle clubs without books on MyClubs page

### DIFF
--- a/capstone-frontend/src/components/MyClubs.jsx
+++ b/capstone-frontend/src/components/MyClubs.jsx
@@ -38,9 +38,12 @@ class MyClubs extends Component {
           .then(books => books[0])
           .then(book => book.authors && book.authors.length
             ? c.bookTitle = book.title
-            : c.bookTitle = 'Nothing yet'
+            : c.bookTitle = 'Nothing yet!'
           )
-          .catch(e => console.error(e))
+          .catch(e => {
+            console.error(e);
+            c.bookTitle = 'Nothing yet!';
+          })
       )
     )
       .then(this.setState({ clubs: allClubs, fetchingClubs: false }));
@@ -54,9 +57,16 @@ class MyClubs extends Component {
 
     const clubBook = await fetch(`/api/search?gbookId=${newClub.gbookID}`)
         .then(response => response.json())
-        .catch(err => console.log(err));
+        .then(books => books[0])
+        .then(book => book.authors && book.authors.length
+          ? newClub.bookTitle = book.title
+          : newClub.bookTitle = 'Nothing yet!'
+        )
+        .catch(e => {
+          console.error(e);
+          newClub.bookTitle = 'Nothing yet!';
+        });
 
-    newClub.bookTitle = clubBook.title;
     newClub.memberIDs.push(userID);
 
     this.setState({clubs: [...this.state.clubs, newClub], fetchingClubs: false, })


### PR DESCRIPTION
Previously, if a club did not have a gbookID, the MyClubs page fetches would fail. This PR handles this case, and has the club tile read "Nothing yet!" when a club does not have a book. 

![Screenshot 2020-08-05 at 9 53 21 AM](https://user-images.githubusercontent.com/43327083/89421125-a4520800-d701-11ea-8c83-721257ff5a64.png)
