### PR TITLE
Comment out add member button on CreateClub page

### DIFF
--- a/capstone-frontend/src/components/CreateClub.jsx
+++ b/capstone-frontend/src/components/CreateClub.jsx
@@ -46,9 +46,9 @@ class CreateClub extends Component {
             <Form.Control name="description" as="textarea" rows="3" placeholder="Enter club description..." />
           </Form.Group>
           <Row>
-            <Col xs={12}>
+            {/* <Col xs={12}>
                <Button variant="secondary" id="add-members" onClick={this.addMembers}> Add Members </Button> 
-            </Col>
+            </Col> */}
           </Row>
           <Row>
             <Col xs={12}>


### PR DESCRIPTION
This PR removes the Add Members button on the `CreateClub` page. Previously it was a dummy button with no functionality, but we decided to remove it for the time being, until we can create a modal for this purpose. 

![Screenshot 2020-08-05 at 11 49 07 AM](https://user-images.githubusercontent.com/43327083/89434788-f8fd7f00-d711-11ea-82c6-7ca966acbdb8.png)
![Screenshot 2020-08-05 at 11 49 25 AM](https://user-images.githubusercontent.com/43327083/89434795-fa2eac00-d711-11ea-981d-529f449dcebd.png)
