### PR TITLE
Synchronize delete of club members and Possible Login fix

### DIFF
--- a/capstone-frontend/src/LeftSideBar.test.js
+++ b/capstone-frontend/src/LeftSideBar.test.js
@@ -41,9 +41,6 @@ test('renders sidebar test', () => {
   const homeLink = document.getElementById("home-link");
   expect(homeLink).toBeInTheDocument();
 
-  const browseLink = document.getElementById("browse-link");
-  expect(browseLink).toBeInTheDocument();
-
   const myBooksLink = document.getElementById("mybooks-link");
   expect(myBooksLink).toBeInTheDocument();
 

--- a/capstone-frontend/src/components/ClubPage.jsx
+++ b/capstone-frontend/src/components/ClubPage.jsx
@@ -22,6 +22,7 @@ class ClubPage extends Component {
       owner: {},
       members: [],
       meetings: [],
+      deletedMemberId: '',
       fetchingData: false, // Spinner
     }
   }
@@ -33,7 +34,11 @@ class ClubPage extends Component {
     if (index > -1) {
       memberArray.splice(index, 1);
     }
-    this.setState({ members: memberArray });
+
+    const club = this.state.club;
+    club.memberIDs = club.memberIDs.filter(clubMemberId => clubMemberId !== memberID);
+
+    this.setState({ members: memberArray, club, deletedMemberId: memberID });
   }
 
   fetchData = async () => {
@@ -242,6 +247,7 @@ class ClubPage extends Component {
                         updateRemoveMember={this.updateRemoveMember}
                         updateInvites={this.updateInvites}
                         club={this.state.club}
+                        deletedMemberId={this.state.deletedMemberId}
                         text='Search/View Members'
                         checkoutText='Current/Pending Members'
                         btnStyle='btn btn-primary mx-3 my-auto' 

--- a/capstone-frontend/src/components/Login.jsx
+++ b/capstone-frontend/src/components/Login.jsx
@@ -38,7 +38,7 @@ export class Login extends Component {
                 clientId="962122785123-t0pm10o610q77epuh9d1jjs29hamm1nf.apps.googleusercontent.com"
                 buttonText="Sign in with Google"
                 onSuccess={this.loginResponseSuccess}
-                isSignedIn={true}
+                isSignedIn={false}
                 cookiePolicy={"single_host_origin"} />
             </Card.Text>
           </Card.Body>

--- a/capstone-frontend/src/components/SearchUserModal.jsx
+++ b/capstone-frontend/src/components/SearchUserModal.jsx
@@ -35,32 +35,14 @@ export class SearchUserModal extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    
+
     if (this.props.club && this.props.type === 'clubs') {
       if (this.props.deletedMemberId && (this.props.deletedMemberId !== prevProps.deletedMemberId)) {
 
-        const deleteMemberIndex = this.indexOfMemberArray(this.state.addedUsers, this.props.deletedMemberId);
-
-        if (deleteMemberIndex >= 0) {
-          const addedUsers = [...this.state.addedUsers];
-          addedUsers.splice(deleteMemberIndex, 1);
-
-          this.setState({ addedUsers });
-        }
+        const addedUsers = this.state.addedUsers.filter(addedUser => addedUser.id !== this.props.deletedMemberId);
+        this.setState({ addedUsers });
       }
     }
-  }
-  
-  indexOfMemberArray = (arr, provideMemberId) => {
-    let index = 0
-
-    for (const member of arr) {
-      if (member.id === provideMemberId) {
-        return index;
-      }
-      index += 1;
-    }
-    return -1
   }
 
   getUsers = async (searchTerm) => {

--- a/capstone-frontend/src/components/SearchUserModal.jsx
+++ b/capstone-frontend/src/components/SearchUserModal.jsx
@@ -34,6 +34,35 @@ export class SearchUserModal extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    
+    if (this.props.club && this.props.type === 'clubs') {
+      if (this.props.deletedMemberId && (this.props.deletedMemberId !== prevProps.deletedMemberId)) {
+
+        const deleteMemberIndex = this.indexOfMemberArray(this.state.addedUsers, this.props.deletedMemberId);
+
+        if (deleteMemberIndex >= 0) {
+          const addedUsers = [...this.state.addedUsers];
+          addedUsers.splice(deleteMemberIndex, 1);
+
+          this.setState({ addedUsers });
+        }
+      }
+    }
+  }
+  
+  indexOfMemberArray = (arr, provideMemberId) => {
+    let index = 0
+
+    for (const member of arr) {
+      if (member.id === provideMemberId) {
+        return index;
+      }
+      index += 1;
+    }
+    return -1
+  }
+
   getUsers = async (searchTerm) => {
 
     this.setState({ fetchingUsers: true });
@@ -183,7 +212,7 @@ export class SearchUserModal extends Component {
     }
 
     // Add Collaborator to Booklist in Firebase
-    fetch("/api/booklist", {
+    fetch("/api/clubs", {
       method: 'PUT',
       body: JSON.stringify(bookListUpdateJson)
     });
@@ -196,7 +225,7 @@ export class SearchUserModal extends Component {
     }
 
     // Remove Collaborator to Booklist in Firebase
-    fetch("/api/booklist", {
+    fetch("/api/clubs", {
       method: 'PUT',
       body: JSON.stringify(bookListUpdateJson)
     });

--- a/capstone-frontend/src/components/SearchUserModal.jsx
+++ b/capstone-frontend/src/components/SearchUserModal.jsx
@@ -212,7 +212,7 @@ export class SearchUserModal extends Component {
     }
 
     // Add Collaborator to Booklist in Firebase
-    fetch("/api/clubs", {
+    fetch("/api/booklist", {
       method: 'PUT',
       body: JSON.stringify(bookListUpdateJson)
     });
@@ -225,7 +225,7 @@ export class SearchUserModal extends Component {
     }
 
     // Remove Collaborator to Booklist in Firebase
-    fetch("/api/clubs", {
+    fetch("/api/booklist", {
       method: 'PUT',
       body: JSON.stringify(bookListUpdateJson)
     });


### PR DESCRIPTION
# Features/Fixes
- Deleting a club member on the ```ClubPage``` will also update the ```SearchUserModal``` removing the member from ```addedUsers```.

- Possible Login Bug Fix
  - Because of the two distinct but similar project websites:
    - https://sopa-capstone-step-2020.uc.r.appspot.com/
    - https://sopa-capstone-step-2020.appspot.com/
  - A user in theory could be login into both, yet if the user logs out of one, it could cause the user to be unable to logout of the other one. 

  - I think for the future we should try to remove one these and only work on one. Its very confusing and maybe lead to security vulnerabilities. 

# Demo
![ClubPage and Modal Synchronous delete Member Demo](https://user-images.githubusercontent.com/53728084/89473444-15181500-d740-11ea-9f96-250226eaa413.gif)
