### PR TITLE
MyReads Rendering On Unread Book

### DIFF
--- a/capstone-frontend/src/components/BookSearchTile.jsx
+++ b/capstone-frontend/src/components/BookSearchTile.jsx
@@ -28,8 +28,13 @@ class BookSearchTile extends Component {
 
   markUnread = () => {
     fetch(`/api/books?id=${this.state.bookObject.id}`, {method: 'delete'})
-        .then(this.setState({hasRead: false, bookObject: {}}))
-        .catch(e => console.log(e));
+        .then(() => this.setState({hasRead: false, bookObject: {}}))
+        .catch(e => console.error(e));
+
+    // Remove book from MyBooks state if on that page
+    if (this.props.deleteReadBook && window.location.pathname.includes('/myreads')) {
+      this.props.deleteReadBook(this.state.bookObject.id);
+    }
   }
 
   componentDidMount() {

--- a/capstone-frontend/src/components/MyBooks.jsx
+++ b/capstone-frontend/src/components/MyBooks.jsx
@@ -23,6 +23,12 @@ export class MyBooks extends Component {
       .catch(e => console.log(e))
   }
 
+  deleteReadBook = (gbookID) => {
+    // Remove read book without refetching the entire page of books
+    const readBooks = this.state.books.filter(book => book.id !== gbookID);
+    this.setState({ books: readBooks });
+  }
+
   componentDidMount() {
     this._isMounted = true;
     this.setState({ loading: true });
@@ -38,7 +44,9 @@ export class MyBooks extends Component {
       location='search'
       bookLists={this.props.bookLists}
       updateBookLists={this.props.updateBookLists}
-      key={b.id} />)
+      deleteReadBook={this.deleteReadBook}
+      key={b.id}
+      />)
       : <p> You haven't read any books yet, better start reading! </p>
     return (
       <>


### PR DESCRIPTION
# Description
This PR ensures that the MyRead page updates when the 'unread book' button is clicked. 

If the current link includes `/myreads` AND the `deleteReadBook` prop is passed, it will call that function, which will filter out the book in the state of MyBooks which matches the id of the removed book.

I originally considered just checking the `/myreads` link, but there are some cases where someone may name their Club or BookList "myreads" which would cause this to fail since the way we calculate links would end up like `/clubs/myreads` which would cause this function to fire incorrectly. For that reason, I ensure that both of them are true. 